### PR TITLE
유저 프로필 이미지 생성, 수정, 삭제 구현, 이미지dto rename

### DIFF
--- a/src/main/kotlin/com/wafflytime/common/S3Service.kt
+++ b/src/main/kotlin/com/wafflytime/common/S3Service.kt
@@ -8,10 +8,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.amazonaws.util.IOUtils
 import com.wafflytime.post.database.image.ImageColumn
-import com.wafflytime.post.dto.ImageResponse
-import com.wafflytime.post.dto.ImageRequest
-import com.wafflytime.post.dto.S3ImageUrlDto
-import com.wafflytime.post.dto.UpdatePostRequest
+import com.wafflytime.post.dto.*
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
@@ -70,15 +67,22 @@ class S3Service(
         return s3Client.getUrl(bucket, s3FileKey).toString()
     }
 
-    fun gerPreSignedUrlAndS3Url(file: ImageRequest) : S3ImageUrlDto {
-        val fileNameWithUUID = UUID.randomUUID().toString() + "-" + file.fileName
+    fun gerPreSignedUrlAndS3Url(fileName: String) : S3ImageUrlDto {
+        val fileNameWithUUID = UUID.randomUUID().toString() + "-" + fileName
         val s3FileKey = getFolder() + fileNameWithUUID
         val preSignedUrl = getPreSignedUrl(s3FileKey, HttpMethod.PUT)
         val s3Url = s3Client.getUrl(bucket, s3FileKey).toString()
-        return S3ImageUrlDto(file.imageId, file.fileName, s3Url, preSignedUrl, file.description)
+        return S3ImageUrlDto(s3Url, preSignedUrl)
     }
 
-    fun getPreSignedUrlsAndS3Urls(files: List<ImageRequest>?): MutableList<S3ImageUrlDto>? {
+    fun gerPreSignedUrlAndS3Url(file: ImageRequest) : S3PostImageUrlDto {
+        val s3ImageUrlDto = gerPreSignedUrlAndS3Url(file.fileName)
+        return S3PostImageUrlDto(
+            file.imageId, file.fileName,
+            s3ImageUrlDto.s3Url, s3ImageUrlDto.preSignedUrl, file.description)
+    }
+
+    fun getPreSignedUrlsAndS3Urls(files: List<ImageRequest>?): MutableList<S3PostImageUrlDto>? {
         if (files == null) return null
         return files.map { gerPreSignedUrlAndS3Url(it) }.toMutableList()
     }
@@ -95,6 +99,11 @@ class S3Service(
         return imageResponseList
     }
 
+    fun getPreSignedUrlFromS3Key(s3Url: String?) : String? {
+        if (s3Url == null) return null
+        return getPreSignedUrl(parseS3UrlToKey(s3Url), HttpMethod.GET)
+    }
+
     fun deleteFiles(images: Map<String, ImageColumn>?) {
         images?.forEach {
             s3Client.deleteObject(bucket, parseS3UrlToKey(it.value.s3Url))
@@ -107,6 +116,10 @@ class S3Service(
         }
     }
 
+    fun deleteFile(s3FileKey: String?) {
+        s3FileKey?.let { s3Client.deleteObject(bucket, parseS3UrlToKey(it)) }
+    }
+
     @Async("deleteS3FileExecutor")
     fun deleteListOfFiles(listOfImages: List<Map<String, ImageColumn>?>) {
         listOfImages.forEach { deleteFiles(it) }
@@ -115,7 +128,7 @@ class S3Service(
     fun updateImageRequest(
         dbImages: Map<String, ImageColumn>?,
         request: UpdatePostRequest
-    ): MutableList<S3ImageUrlDto>? {
+    ): MutableList<S3PostImageUrlDto>? {
         if (dbImages == null) return getPreSignedUrlsAndS3Urls(request.images)
         if (request.images == null) return null
 
@@ -124,13 +137,13 @@ class S3Service(
         반드시 유저의 게시물 그 상태를 그대로 전달해주어야 한다(사진이 바뀌지 않았더라도 사진 정보를 그대로 UpdateRequest 에 담아서).
         프론트에서 이걸 어떻게 전달해주는게 좋을지 프론트랑 얘개히보고 수정하면 좋을 듯 하다
          **/
-        val s3ImageUrlDtoList = mutableListOf<S3ImageUrlDto>()
+        val s3PostImageUrlDtoList = mutableListOf<S3PostImageUrlDto>()
         request.images.forEach {
             if (dbImages.containsKey(it.fileName)) {
                 // 현재는 client 바뀐 정보만 전달하는 것이 아니라 현재 이미지 state 전달한다고 가정 - 이 부분 추후에 프론트와 이야기
                 // 이미 s3에 푸시된 이미지라 s3 url이 존재하기 때문에 preSignedUrl을 null로 넘겨준다
-                s3ImageUrlDtoList.add(
-                    S3ImageUrlDto(
+                s3PostImageUrlDtoList.add(
+                    S3PostImageUrlDto(
                         imageId = it.imageId,
                         fileName = it.fileName,
                         s3Url = dbImages.get(it.fileName)!!.s3Url,
@@ -140,10 +153,10 @@ class S3Service(
                 )
             } else {
                 // new image
-                s3ImageUrlDtoList.add(gerPreSignedUrlAndS3Url(it))
+                s3PostImageUrlDtoList.add(gerPreSignedUrlAndS3Url(it))
             }
         }
         deleteFiles(request.deletedFileNames?.map { dbImages.get(it)?.s3Url })
-        return s3ImageUrlDtoList
+        return s3PostImageUrlDtoList
     }
 }

--- a/src/main/kotlin/com/wafflytime/post/database/image/ImageColumn.kt
+++ b/src/main/kotlin/com/wafflytime/post/database/image/ImageColumn.kt
@@ -1,6 +1,6 @@
 package com.wafflytime.post.database.image
 
-import com.wafflytime.post.dto.S3ImageUrlDto
+import com.wafflytime.post.dto.S3PostImageUrlDto
 
 data class ImageColumn(
     val imageId: Int,
@@ -11,8 +11,8 @@ data class ImageColumn(
     constructor() : this(0, "", null)
 
     companion object {
-        fun of(s3ImageUrlDto: S3ImageUrlDto) : ImageColumn {
-            return ImageColumn(imageId = s3ImageUrlDto.imageId, s3Url = s3ImageUrlDto.s3Url, description = s3ImageUrlDto.description)
+        fun of(s3PostImageUrlDto: S3PostImageUrlDto) : ImageColumn {
+            return ImageColumn(imageId = s3PostImageUrlDto.imageId, s3Url = s3PostImageUrlDto.s3Url, description = s3PostImageUrlDto.description)
         }
     }
 }

--- a/src/main/kotlin/com/wafflytime/post/dto/ImageDto.kt
+++ b/src/main/kotlin/com/wafflytime/post/dto/ImageDto.kt
@@ -13,16 +13,21 @@ data class ImageResponse(
     val description: String?
 ) {
     companion object {
-        fun of(s3ImageUrlDto: S3ImageUrlDto) : ImageResponse {
-            return ImageResponse(s3ImageUrlDto.imageId, s3ImageUrlDto.preSignedUrl, s3ImageUrlDto.description)
+        fun of(s3PostImageUrlDto: S3PostImageUrlDto) : ImageResponse {
+            return ImageResponse(s3PostImageUrlDto.imageId, s3PostImageUrlDto.preSignedUrl, s3PostImageUrlDto.description)
         }
     }
 }
 
-data class S3ImageUrlDto(
+data class S3PostImageUrlDto(
     val imageId: Int,
     val fileName: String,
     val s3Url: String,
     val preSignedUrl: String?,
     val description: String?
+)
+
+data class S3ImageUrlDto(
+    val s3Url: String,
+    val preSignedUrl: String?
 )

--- a/src/main/kotlin/com/wafflytime/post/service/PostService.kt
+++ b/src/main/kotlin/com/wafflytime/post/service/PostService.kt
@@ -106,8 +106,8 @@ class PostService(
         return post
     }
 
-    fun getImagesEntityFromS3ImageUrl(s3ImageUrlDtoList: MutableList<S3ImageUrlDto>?) : Map<String, ImageColumn>? {
-        return s3ImageUrlDtoList?.map { it.fileName to ImageColumn.of(it) }?.toMap()
+    fun getImagesEntityFromS3ImageUrl(s3PostImageUrlDtoList: MutableList<S3PostImageUrlDto>?) : Map<String, ImageColumn>? {
+        return s3PostImageUrlDtoList?.map { it.fileName to ImageColumn.of(it) }?.toMap()
     }
 
     @Transactional

--- a/src/main/kotlin/com/wafflytime/user/info/api/UserController.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/api/UserController.kt
@@ -4,6 +4,7 @@ import com.wafflytime.config.UserIdFromToken
 import com.wafflytime.post.dto.PostResponse
 import com.wafflytime.user.info.api.dto.DeleteScrapResponse
 import com.wafflytime.user.info.api.dto.UpdateUserInfoRequest
+import com.wafflytime.user.info.api.dto.UploadProfileImageRequest
 import com.wafflytime.user.info.api.dto.UserInfo
 import com.wafflytime.user.info.service.UserService
 import jakarta.validation.Valid
@@ -27,6 +28,21 @@ class UserController(
         @Valid @RequestBody request: UpdateUserInfoRequest,
     ): UserInfo {
         return userService.updateUserInfo(userId, request)
+    }
+
+    @PutMapping("/api/user/me/profile")
+    fun updateProfileImage(
+        @UserIdFromToken userId: Long,
+        @Valid @RequestBody request: UploadProfileImageRequest,
+    ) : ResponseEntity<UserInfo> {
+        return ResponseEntity.ok(userService.updateProfileImage(userId, request))
+    }
+
+    @DeleteMapping("/api/user/me/profile")
+    fun updateProfileImage(
+        @UserIdFromToken userId: Long
+    ) : ResponseEntity<UserInfo> {
+        return ResponseEntity.ok(userService.deleteProfileImage(userId))
     }
 
     @GetMapping("/api/user/myscrap")
@@ -54,5 +70,4 @@ class UserController(
     ) : ResponseEntity<Page<PostResponse>> {
         return ResponseEntity.ok(userService.getMyPosts(userId, page, size))
     }
-
 }

--- a/src/main/kotlin/com/wafflytime/user/info/api/dto/UploadProfileImageRequest.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/api/dto/UploadProfileImageRequest.kt
@@ -1,0 +1,5 @@
+package com.wafflytime.user.info.api.dto
+
+data class UploadProfileImageRequest(
+    val fileName: String
+)

--- a/src/main/kotlin/com/wafflytime/user/info/api/dto/UserInfo.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/api/dto/UserInfo.kt
@@ -7,6 +7,7 @@ data class UserInfo(
     val socialEmail: String?,
     val univEmail: String?,
     val nickname: String?,
+    var profilePreSignedUrl: String? = null
 ) {
 
     companion object {
@@ -16,6 +17,16 @@ data class UserInfo(
                 socialEmail,
                 univEmail,
                 nickname,
+            )
+        }
+
+        fun of(entity: UserEntity, preSignedUrl: String?): UserInfo = entity.run {
+            UserInfo(
+                loginId,
+                socialEmail,
+                univEmail,
+                nickname,
+                preSignedUrl
             )
         }
     }

--- a/src/main/kotlin/com/wafflytime/user/info/database/UserEntity.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/database/UserEntity.kt
@@ -18,6 +18,8 @@ class UserEntity(
     var nickname: String? = null,
     val isAdmin: Boolean = false,
 
+    var profileImage: String? = null
+
     ): BaseTimeEntity() {
 
     fun update(password: String?, nickname: String?) {

--- a/src/main/kotlin/com/wafflytime/user/info/service/UserService.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/service/UserService.kt
@@ -1,5 +1,6 @@
 package com.wafflytime.user.info.service
 
+import com.wafflytime.common.S3Service
 import com.wafflytime.exception.WafflyTime401
 import com.wafflytime.exception.WafflyTime404
 import com.wafflytime.exception.WafflyTime409
@@ -8,6 +9,7 @@ import com.wafflytime.post.database.ScrapRepository
 import com.wafflytime.post.dto.PostResponse
 import com.wafflytime.user.info.api.dto.DeleteScrapResponse
 import com.wafflytime.user.info.api.dto.UpdateUserInfoRequest
+import com.wafflytime.user.info.api.dto.UploadProfileImageRequest
 import com.wafflytime.user.info.api.dto.UserInfo
 import com.wafflytime.user.info.database.UserEntity
 import com.wafflytime.user.info.database.UserRepository
@@ -28,6 +30,8 @@ interface UserService {
     fun getMyScraps(userId: Long, page:Int, size:Int): Page<PostResponse>
     fun deleteScrap(userId: Long, postId: Long): DeleteScrapResponse
     fun getMyPosts(userId: Long, page: Int, size: Int): Page<PostResponse>
+    fun updateProfileImage(userId: Long, request: UploadProfileImageRequest): UserInfo
+    fun deleteProfileImage(userId: Long): UserInfo
 }
 
 @Service
@@ -35,7 +39,8 @@ class UserServiceImpl (
     private val passwordEncoder: PasswordEncoder,
     private val userRepository: UserRepository,
     private val scrapRepository: ScrapRepository,
-    private val postRepository: PostRepository
+    private val postRepository: PostRepository,
+    private val s3Service: S3Service
 ) : UserService {
 
     @Transactional
@@ -47,7 +52,7 @@ class UserServiceImpl (
     @Transactional
     override fun getUserInfo(userId: Long): UserInfo {
         val user = getUserById(userId)
-        return UserInfo.of(user)
+        return UserInfo.of(user, preSignedUrl = s3Service.getPreSignedUrlFromS3Key(user.profileImage))
     }
 
     @Transactional
@@ -59,6 +64,8 @@ class UserServiceImpl (
                 nickname,
             )
         }
+        // 이 update api는 nickname과 password만 업데이트 하기 때문에 유저가 프로필 사진이 있다고 하더라도, preSignedUrl이 null로 내려감
+        // 프론트에게 업데이트 하는 경우에 받은 response는 수정한 내용만 반영하고 presSingedUrl null 인건 무시하고 이미 유저에게 보여주고 있는 사진 그대로 보여주기를 요청
         return UserInfo.of(user)
     }
 
@@ -95,6 +102,26 @@ class UserServiceImpl (
         ).map {
             PostResponse.of(it)
         }
+    }
+
+    @Transactional
+    override fun updateProfileImage(userId: Long, request: UploadProfileImageRequest): UserInfo {
+        val user = getUserById(userId)
+        // 기존에 저장된 이미지가 존재할 경우 삭제
+        user.profileImage?.let { s3Service.deleteFile(it) }
+
+        val s3ImageUrlDto = s3Service.gerPreSignedUrlAndS3Url(request.fileName)
+        user.profileImage = s3ImageUrlDto.s3Url
+        return UserInfo.of(user, s3ImageUrlDto.preSignedUrl)
+    }
+
+    @Transactional
+    override fun deleteProfileImage(userId: Long): UserInfo {
+        val user = getUserById(userId)
+        val s3FileKey = user.profileImage
+        s3Service.deleteFile(s3FileKey)
+        user.profileImage = null
+        return UserInfo.of(user)
     }
 
     private fun getUserById(userId: Long): UserEntity {


### PR DESCRIPTION
프로필 이미지는 기본적으로 없고 내 정보 화면에서 프로필 수정을 하는게 처음 생성하는것과 마찬가지. 그래서 PUT method 만 세팅,
이미지 관련 put delete method가 updateMyInfo와 구분되는게 프론트에서 더 편할 것  같아서 구분지어서 구현했습니다

![IMG_C328C7B67F9D-1](https://user-images.githubusercontent.com/60849888/212469326-888aac0f-e94c-470a-a41d-50b5c85e8a4e.jpeg)
