### PR TITLE
Feature/chat

### DIFF
--- a/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
+++ b/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
@@ -1,0 +1,60 @@
+package com.wafflytime.chat.api
+
+import com.wafflytime.chat.dto.ChatSimpleInfo
+import com.wafflytime.chat.dto.CreateChatRequest
+import com.wafflytime.chat.dto.MessageInfo
+import com.wafflytime.chat.dto.SendMessageRequest
+import com.wafflytime.chat.service.ChatService
+import com.wafflytime.config.UserIdFromToken
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ChatController(
+    private val chatService: ChatService,
+) {
+
+    @PostMapping("/api/board/{boardId}/post/{postId}/chat")
+    fun createChat(
+        @UserIdFromToken userId: Long,
+        @PathVariable boardId: Long,
+        @PathVariable postId: Long,
+        @RequestParam(required = false, value = "replyId") replyId: Long?,
+        @Valid @RequestBody request: CreateChatRequest,
+    ): ChatSimpleInfo {
+        return chatService.createChat(userId, boardId, postId, replyId, request)
+    }
+
+    @PostMapping("/api/chat/{chatId}")
+    fun sendMessage(
+        @UserIdFromToken userId: Long,
+        @PathVariable chatId: Long,
+        @Valid @RequestBody request: SendMessageRequest,
+    ): MessageInfo {
+        return chatService.sendMessage(userId, chatId, request)
+    }
+
+    @GetMapping("/api/chat")
+    fun getChatList(
+        @UserIdFromToken userId: Long,
+    ): List<ChatSimpleInfo> {
+        return chatService.getChats(userId)
+    }
+
+    @GetMapping("/api/chat/{chatId}/messages")
+    fun getMessages(
+        @UserIdFromToken userId: Long,
+        @PathVariable chatId: Long,
+        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
+        @RequestParam(required = false, value = "size") size: Int?,
+    ): Page<MessageInfo> {
+        return chatService.getMessages(userId, chatId, page, size)
+    }
+
+}

--- a/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
+++ b/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
@@ -1,19 +1,11 @@
 package com.wafflytime.chat.api
 
-import com.wafflytime.chat.dto.ChatSimpleInfo
-import com.wafflytime.chat.dto.CreateChatRequest
-import com.wafflytime.chat.dto.MessageInfo
-import com.wafflytime.chat.dto.SendMessageRequest
+import com.wafflytime.chat.dto.*
 import com.wafflytime.chat.service.ChatService
 import com.wafflytime.config.UserIdFromToken
 import jakarta.validation.Valid
 import org.springframework.data.domain.Page
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class ChatController(
@@ -27,7 +19,7 @@ class ChatController(
         @PathVariable postId: Long,
         @RequestParam(required = false, value = "replyId") replyId: Long?,
         @Valid @RequestBody request: CreateChatRequest,
-    ): ChatSimpleInfo {
+    ): CreateChatResponse {
         return chatService.createChat(userId, boardId, postId, replyId, request)
     }
 
@@ -55,6 +47,15 @@ class ChatController(
         @RequestParam(required = false, value = "size") size: Int?,
     ): Page<MessageInfo> {
         return chatService.getMessages(userId, chatId, page, size)
+    }
+
+    @PutMapping("/api/chat/{chatId}")
+    fun updateChatBlock(
+        @UserIdFromToken userId: Long,
+        @PathVariable chatId: Long,
+        @Valid @RequestBody request: UpdateChatBlockRequest,
+    ): ChatSimpleInfo {
+        return chatService.updateChatBlock(userId, chatId, request)
     }
 
 }

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 @Table(name = "chat")
 class ChatEntity(
+    val postId: Long?,
     @ManyToOne
     @JoinColumn(name = "participant1_id")
     val participant1: UserEntity,

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
@@ -13,14 +13,18 @@ class ChatEntity(
     val participant1: UserEntity,
     val isAnonymous1: Boolean,
     var unread1: Int = 0,
+    var blocked1: Boolean = false,
     @ManyToOne
     @JoinColumn(name = "participant2_id")
     val participant2: UserEntity,
     val isAnonymous2: Boolean,
     var unread2: Int = 0,
+    var blocked2: Boolean = false,
     @OneToMany(mappedBy = "chat", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY)
     val messages: MutableList<MessageEntity> = mutableListOf()
 ): BaseTimeEntity() {
+
+    fun isBlocked() = blocked1 || blocked2
 
     fun addMessage(message: MessageEntity) {
         messages.add(message)

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
@@ -1,0 +1,33 @@
+package com.wafflytime.chat.database
+
+import com.wafflytime.common.BaseTimeEntity
+import com.wafflytime.user.info.database.UserEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "chat")
+class ChatEntity(
+    @ManyToOne
+    @JoinColumn(name = "participant1_id")
+    val participant1: UserEntity,
+    val isAnonymous1: Boolean,
+    var unread1: Int = 0,
+    @ManyToOne
+    @JoinColumn(name = "participant2_id")
+    val participant2: UserEntity,
+    val isAnonymous2: Boolean,
+    var unread2: Int = 0,
+    @OneToMany(mappedBy = "chat", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY)
+    val messages: MutableList<MessageEntity> = mutableListOf()
+): BaseTimeEntity() {
+
+    fun addMessage(message: MessageEntity) {
+        messages.add(message)
+
+        when (message.sender) {
+            participant1 -> unread2++
+            participant2 -> unread1++
+        }
+    }
+
+}

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
@@ -12,6 +12,8 @@ interface ChatRepository : JpaRepository<ChatEntity, Long>, ChatRepositorySuppor
 
 interface ChatRepositorySupport {
     fun findByParticipantIdWithLastMessage(userId: Long): List<ChatEntity>
+    fun findByAllConditions(postId: Long, participantId1: Long, isAnonymous1: Boolean, participantId2: Long, isAnonymous2: Boolean) : ChatEntity?
+    fun findByBothParticipantId(participantId1: Long, participantId2: Long) : ChatEntity?
 }
 
 @Repository
@@ -37,6 +39,37 @@ class ChatRepositorySupportImpl(
             .where(userEntity2.id.eq(chatEntity.participant2.id))
             .fetchJoin()
             .fetch()
+    }
+
+    override fun findByAllConditions(
+        postId: Long,
+        participantId1: Long,
+        isAnonymous1: Boolean,
+        participantId2: Long,
+        isAnonymous2: Boolean
+    ): ChatEntity? {
+        return jpaQueryFactory
+            .selectFrom(chatEntity)
+            .where(
+                chatEntity.postId.eq(postId)
+                    .and(chatEntity.participant1.id.eq(participantId1))
+                    .and(chatEntity.isAnonymous1.eq(isAnonymous1))
+                    .and(chatEntity.participant2.id.eq(participantId2))
+                    .and(chatEntity.isAnonymous2.eq(isAnonymous2))
+            )
+            .fetchOne()
+    }
+
+    override fun findByBothParticipantId(participantId1: Long, participantId2: Long) : ChatEntity? {
+        return jpaQueryFactory
+            .selectFrom(chatEntity)
+            .where(
+                chatEntity.participant1.id.eq(participantId1)
+                    .and(chatEntity.isAnonymous1.isTrue)
+                    .and(chatEntity.participant2.id.eq(participantId2))
+                    .and(chatEntity.isAnonymous2.isTrue)
+            )
+            .fetchOne()
     }
 
 }

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
@@ -19,8 +19,6 @@ class ChatRepositorySupportImpl(
     private val jpaQueryFactory: JPAQueryFactory
 ) : QuerydslRepositorySupport(ChatEntity::class.java), ChatRepositorySupport {
 
-
-
     override fun findByParticipantIdWithLastMessage(userId: Long): List<ChatEntity> {
         val userEntity1 = QUserEntity("userEntity1")
         val userEntity2 = QUserEntity("userEntity2")

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
@@ -1,0 +1,44 @@
+package com.wafflytime.chat.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflytime.chat.database.QChatEntity.chatEntity
+import com.wafflytime.chat.database.QMessageEntity.messageEntity
+import com.wafflytime.user.info.database.QUserEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
+
+interface ChatRepository : JpaRepository<ChatEntity, Long>, ChatRepositorySupport
+
+interface ChatRepositorySupport {
+    fun findByParticipantIdWithLastMessage(userId: Long): List<ChatEntity>
+}
+
+@Repository
+class ChatRepositorySupportImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : QuerydslRepositorySupport(ChatEntity::class.java), ChatRepositorySupport {
+
+
+
+    override fun findByParticipantIdWithLastMessage(userId: Long): List<ChatEntity> {
+        val userEntity1 = QUserEntity("userEntity1")
+        val userEntity2 = QUserEntity("userEntity2")
+
+        return jpaQueryFactory
+            .selectFrom(chatEntity)
+            .where(chatEntity.participant1.id.eq(userId).or(chatEntity.participant2.id.eq(userId)))
+            .orderBy(chatEntity.modifiedAt.desc())
+            .leftJoin(chatEntity.messages, messageEntity)
+            .where(messageEntity.chat.id.eq(chatEntity.id))
+            .fetchJoin()
+            .leftJoin(chatEntity.participant1, userEntity1)
+            .where(userEntity1.id.eq(chatEntity.participant1.id))
+            .fetchJoin()
+            .leftJoin(chatEntity.participant2, userEntity2)
+            .where(userEntity2.id.eq(chatEntity.participant2.id))
+            .fetchJoin()
+            .fetch()
+    }
+
+}

--- a/src/main/kotlin/com/wafflytime/chat/database/MessageEntity.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/MessageEntity.kt
@@ -1,0 +1,23 @@
+package com.wafflytime.chat.database
+
+import com.wafflytime.common.BaseTimeEntity
+import com.wafflytime.user.info.database.UserEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotBlank
+
+@Entity
+@Table(name = "message")
+class MessageEntity(
+    @ManyToOne
+    @JoinColumn(name = "chat_id")
+    val chat: ChatEntity,
+    @ManyToOne
+    @JoinColumn(name = "sender_id")
+    val sender: UserEntity? = null, // null 인 경우 안내 메세지
+    @field:NotBlank
+    val content: String,
+): BaseTimeEntity() {
+}

--- a/src/main/kotlin/com/wafflytime/chat/database/MessageRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/MessageRepository.kt
@@ -1,0 +1,39 @@
+package com.wafflytime.chat.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflytime.chat.database.QMessageEntity.messageEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
+
+interface MessageRepository : JpaRepository<MessageEntity, Long>, MessageRepositorySupport
+
+interface MessageRepositorySupport {
+    fun findByChatIdPageable(chatId: Long, pageable: Pageable): Page<MessageEntity>
+}
+
+@Repository
+class MessageRepositorySupportImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : QuerydslRepositorySupport(MessageEntity::class.java), MessageRepositorySupport {
+
+    override fun findByChatIdPageable(chatId: Long, pageable: Pageable): Page<MessageEntity> {
+        val query = jpaQueryFactory
+            .selectFrom(messageEntity)
+            .where(messageEntity.chat.id.eq(chatId))
+
+        val count = query.fetch().size.toLong()
+        val result = query
+            .orderBy(messageEntity.createdAt.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+            .reversed()
+
+        return PageImpl(result, pageable, count)
+    }
+
+}

--- a/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
@@ -1,0 +1,37 @@
+package com.wafflytime.chat.dto
+
+import com.wafflytime.chat.database.ChatEntity
+
+data class ChatSimpleInfo(
+    val id: Long,
+    val target: String,
+    val recentMessage: String,
+    val unread: Int,
+) {
+
+    companion object {
+
+        private const val anonymousName = "익명"
+
+        fun of(userId: Long, entity: ChatEntity): ChatSimpleInfo = entity.run {
+            val recentMessage = messages.last()
+
+            when (userId) {
+                participant1.id -> ChatSimpleInfo(
+                    id,
+                    if (isAnonymous1) anonymousName else participant1.nickname,
+                    recentMessage.content,
+                    unread1,
+                )
+                participant2.id -> ChatSimpleInfo(
+                    id,
+                    if (isAnonymous2) anonymousName else participant2.nickname,
+                    recentMessage.content,
+                    unread2,
+                )
+                else -> throw TODO()
+            }
+        }
+
+    }
+}

--- a/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
@@ -8,6 +8,7 @@ data class ChatSimpleInfo(
     val target: String,
     val recentMessage: String,
     val unread: Int,
+    val blocked: Boolean,
 ) {
 
     companion object {
@@ -23,12 +24,14 @@ data class ChatSimpleInfo(
                     if (isAnonymous1) anonymousName else participant1.nickname,
                     recentMessage.content,
                     unread1,
+                    blocked1,
                 )
                 participant2.id -> ChatSimpleInfo(
                     id,
                     if (isAnonymous2) anonymousName else participant2.nickname,
                     recentMessage.content,
                     unread2,
+                    blocked2,
                 )
                 else -> throw UserChatMismatch
             }

--- a/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
@@ -1,6 +1,7 @@
 package com.wafflytime.chat.dto
 
 import com.wafflytime.chat.database.ChatEntity
+import com.wafflytime.chat.exception.UserChatMismatch
 
 data class ChatSimpleInfo(
     val id: Long,
@@ -29,7 +30,7 @@ data class ChatSimpleInfo(
                     recentMessage.content,
                     unread2,
                 )
-                else -> throw TODO()
+                else -> throw UserChatMismatch
             }
         }
 

--- a/src/main/kotlin/com/wafflytime/chat/dto/CreateChatRequest.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/CreateChatRequest.kt
@@ -1,0 +1,6 @@
+package com.wafflytime.chat.dto
+
+data class CreateChatRequest(
+    val isAnonymous: Boolean,
+    val content: String,
+)

--- a/src/main/kotlin/com/wafflytime/chat/dto/CreateChatResponse.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/CreateChatResponse.kt
@@ -1,0 +1,8 @@
+package com.wafflytime.chat.dto
+
+data class CreateChatResponse(
+    val new: Boolean,
+    val chatInfo: ChatSimpleInfo,
+    val systemMessageInfo: MessageInfo?,
+    val firstMessageInfo: MessageInfo,
+)

--- a/src/main/kotlin/com/wafflytime/chat/dto/MessageInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/MessageInfo.kt
@@ -1,0 +1,21 @@
+package com.wafflytime.chat.dto
+
+import com.wafflytime.chat.database.MessageEntity
+import com.wafflytime.common.DateTimeResponse
+
+data class MessageInfo(
+    val sentAt: DateTimeResponse,
+    val received: Boolean,
+    val content: String,
+) {
+
+    companion object {
+        fun of(userId: Long, entity: MessageEntity): MessageInfo = entity.run {
+            MessageInfo(
+                DateTimeResponse.of(createdAt!!),
+                sender?.let { userId != it.id } ?: true,
+                content,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflytime/chat/dto/MessageInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/MessageInfo.kt
@@ -2,6 +2,7 @@ package com.wafflytime.chat.dto
 
 import com.wafflytime.chat.database.MessageEntity
 import com.wafflytime.common.DateTimeResponse
+import java.time.LocalDateTime
 
 data class MessageInfo(
     val sentAt: DateTimeResponse,
@@ -10,9 +11,10 @@ data class MessageInfo(
 ) {
 
     companion object {
+
         fun of(userId: Long, entity: MessageEntity): MessageInfo = entity.run {
             MessageInfo(
-                DateTimeResponse.of(createdAt!!),
+                DateTimeResponse.of(createdAt ?: LocalDateTime.now()),
                 sender?.let { userId != it.id } ?: true,
                 content,
             )

--- a/src/main/kotlin/com/wafflytime/chat/dto/SendMessageRequest.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/SendMessageRequest.kt
@@ -1,0 +1,8 @@
+package com.wafflytime.chat.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class SendMessageRequest(
+    @NotBlank
+    val content: String,
+)

--- a/src/main/kotlin/com/wafflytime/chat/dto/UpdateChatBlockRequest.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/UpdateChatBlockRequest.kt
@@ -1,0 +1,5 @@
+package com.wafflytime.chat.dto
+
+data class UpdateChatBlockRequest(
+    val block: Boolean,
+)

--- a/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
+++ b/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
@@ -9,6 +9,9 @@ open class Chat403(msg: String, errorCode: Int) : ChatException(msg, errorCode, 
 open class Chat404(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.NOT_FOUND)
 open class Chat409(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.CONFLICT)
 
-object ChatNotFound : Chat404("해당 id의 채팅방을 찾을 수 없습니다", 0)
-object UserChatMismatch : Chat403("해당 유저가 속한 채팅방이 아닙니다", 1)
+object ChatNotFound : Chat404("해당 id의 채팅을 찾을 수 없습니다", 0)
+object UserChatMismatch : Chat403("해당 유저가 속한 채팅이 아닙니다", 1)
 object NoMoreUnreadMessages : Chat400("안 읽은 메세지가 남아있지 않습니다", 2)
+object SelfChatForbidden : Chat400("자신에게 채팅을 보낼 수 없습니다", 3)
+object AlreadyBlocked : Chat400("이미 차단한 채팅입니다", 4)
+object AlreadyUnblocked : Chat400("이미 차단 해제한 채팅입니다", 5)

--- a/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
+++ b/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
@@ -1,0 +1,14 @@
+package com.wafflytime.chat.exception
+
+import com.wafflytime.exception.ChatException
+import org.springframework.http.HttpStatus
+
+open class Chat400(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.BAD_REQUEST)
+open class Chat401(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.UNAUTHORIZED)
+open class Chat403(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.FORBIDDEN)
+open class Chat404(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.NOT_FOUND)
+open class Chat409(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.CONFLICT)
+
+object ChatNotFound : Chat404("해당 id의 채팅방을 찾을 수 없습니다", 0)
+object UserChatMismatch : Chat403("해당 유저가 속한 채팅방이 아닙니다", 1)
+object NoMoreUnreadMessages : Chat400("안 읽은 메세지가 남아있지 않습니다", 2)

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -1,0 +1,137 @@
+package com.wafflytime.chat.service
+
+import com.wafflytime.chat.database.ChatEntity
+import com.wafflytime.chat.database.ChatRepository
+import com.wafflytime.chat.database.MessageEntity
+import com.wafflytime.chat.database.MessageRepository
+import com.wafflytime.chat.dto.ChatSimpleInfo
+import com.wafflytime.chat.dto.CreateChatRequest
+import com.wafflytime.chat.dto.MessageInfo
+import com.wafflytime.chat.dto.SendMessageRequest
+import com.wafflytime.post.service.PostService
+import com.wafflytime.reply.service.ReplyService
+import com.wafflytime.user.info.database.UserEntity
+import com.wafflytime.user.info.service.UserService
+import jakarta.transaction.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import java.time.format.DateTimeFormatter
+
+interface ChatService {
+    fun createChat(userId: Long, sourceBoardId: Long, sourcePostId: Long, sourceReplyId: Long? = null, request: CreateChatRequest): ChatSimpleInfo
+    fun sendMessage(userId: Long, chatId: Long, request: SendMessageRequest): MessageInfo
+    fun getChats(userId: Long): List<ChatSimpleInfo>
+    fun getMessages(userId: Long, chatId: Long, page: Int, size: Int?): Page<MessageInfo>
+}
+
+@Service
+class ChatServiceImpl(
+    private val userService: UserService,
+    private val postService: PostService,
+    private val replyService: ReplyService,
+    private val chatRepository: ChatRepository,
+    private val messageRepository: MessageRepository,
+): ChatService {
+
+    @Transactional
+    override fun createChat(userId: Long, sourceBoardId: Long, sourcePostId: Long, sourceReplyId: Long?, request: CreateChatRequest): ChatSimpleInfo {
+        val user = userService.getUser(userId)
+        val sourcePost = postService.validateBoardAndPost(sourceBoardId, sourcePostId)
+        val sourceBoard = sourcePost.board
+        val sourceReply = sourceReplyId?.let {
+            replyService.getReplyEntity(sourcePostId, it)
+        }
+
+        val chat = if (sourceReply == null) {
+            chatRepository.save(
+                ChatEntity(
+                    participant1 = user, isAnonymous1 = request.isAnonymous,
+                    participant2 = sourcePost.writer, isAnonymous2 = sourcePost.isWriterAnonymous,
+                )
+            )
+        } else {
+            chatRepository.save(
+                ChatEntity(
+                    participant1 = user, isAnonymous1 = request.isAnonymous,
+                    participant2 = sourceReply.writer, isAnonymous2 = sourceReply.isWriterAnonymous,
+                )
+            )
+        }
+
+        val infoMessage = messageRepository.save(
+            MessageEntity(
+                chat = chat,
+                content = "${sourceBoard.title}에 ${DateTimeFormatter.ofPattern("MM/DD hh:mm").format(sourcePost.createdAt)} 작성된 글을 통해 온 쪽지입니다.",
+            )
+        )
+        val firstMessage = messageRepository.save(
+            MessageEntity(
+                chat = chat,
+                content = request.content
+            )
+        )
+        chat.addMessage(infoMessage)
+        chat.addMessage(firstMessage)
+
+        return ChatSimpleInfo.of(userId, chat)
+    }
+
+    @Transactional
+    override fun sendMessage(userId: Long, chatId: Long, request: SendMessageRequest): MessageInfo {
+        val user = userService.getUser(userId)
+        val chat = getChatEntity(chatId)
+        validateChatParticipant(user, chat)
+
+        val message = messageRepository.save(
+            MessageEntity(chat, user, request.content)
+        )
+        chat.addMessage(message)
+
+        return MessageInfo.of(userId, message)
+    }
+
+    @Transactional
+    override fun getChats(userId: Long): List<ChatSimpleInfo> {
+        return chatRepository.findByParticipantIdWithLastMessage(userId)
+            .map { ChatSimpleInfo.of(userId, it) }
+    }
+
+    @Transactional
+    override fun getMessages(userId: Long, chatId: Long, page: Int, size: Int?): Page<MessageInfo> {
+        val chat = getChatEntity(chatId)
+        val defaultSize: Int
+        chat.run {
+            when (userId) {
+                participant1.id -> {
+                    defaultSize = unread1
+                    unread1 = 0
+                }
+                participant2.id -> {
+                    defaultSize = unread2
+                    unread2 = 0
+                }
+                else -> throw TODO()
+            }
+        }
+
+        val size = size ?: defaultSize
+        if (size == 0) throw TODO()
+
+        val pageRequest = PageRequest.of(page, size)
+        return messageRepository.findByChatIdPageable(chatId, pageRequest)
+            .map { MessageInfo.of(userId, it) }
+    }
+
+    private fun getChatEntity(chatId: Long): ChatEntity {
+        return chatRepository.findByIdOrNull(chatId)
+            ?: throw TODO()
+    }
+
+    private fun validateChatParticipant(user: UserEntity, chat: ChatEntity) {
+        if (chat.participant1 != user && chat.participant2 != user)
+            throw TODO()
+    }
+
+}

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -8,6 +8,9 @@ import com.wafflytime.chat.dto.ChatSimpleInfo
 import com.wafflytime.chat.dto.CreateChatRequest
 import com.wafflytime.chat.dto.MessageInfo
 import com.wafflytime.chat.dto.SendMessageRequest
+import com.wafflytime.chat.exception.ChatNotFound
+import com.wafflytime.chat.exception.NoMoreUnreadMessages
+import com.wafflytime.chat.exception.UserChatMismatch
 import com.wafflytime.post.service.PostService
 import com.wafflytime.reply.service.ReplyService
 import com.wafflytime.user.info.database.UserEntity
@@ -112,12 +115,12 @@ class ChatServiceImpl(
                     defaultSize = unread2
                     unread2 = 0
                 }
-                else -> throw TODO()
+                else -> throw UserChatMismatch
             }
         }
 
         val size = size ?: defaultSize
-        if (size == 0) throw TODO()
+        if (size == 0) throw NoMoreUnreadMessages
 
         val pageRequest = PageRequest.of(page, size)
         return messageRepository.findByChatIdPageable(chatId, pageRequest)
@@ -126,12 +129,12 @@ class ChatServiceImpl(
 
     private fun getChatEntity(chatId: Long): ChatEntity {
         return chatRepository.findByIdOrNull(chatId)
-            ?: throw TODO()
+            ?: throw ChatNotFound
     }
 
     private fun validateChatParticipant(user: UserEntity, chat: ChatEntity) {
         if (chat.participant1 != user && chat.participant2 != user)
-            throw TODO()
+            throw UserChatMismatch
     }
 
 }

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -126,21 +126,21 @@ class ChatServiceImpl(
         val chat = getChatEntity(chatId)
         val defaultSize: Int
         chat.run {
-            defaultSize = when (userId) {
-                participant1.id -> unread1
-                participant2.id -> unread2
+            when (userId) {
+                participant1.id -> {
+                    defaultSize = unread1
+                    unread1 = 0
+                }
+                participant2.id -> {
+                    defaultSize = unread2
+                    unread2 = 0
+                }
                 else -> throw UserChatMismatch
             }
         }
 
         val size = size ?: defaultSize
         if (size == 0) throw NoMoreUnreadMessages
-        chat.run {
-            when (userId) {
-                participant1.id -> unread1 = max(0, unread1 - size)
-                participant2.id -> unread2 = max(0, unread2 - size)
-            }
-        }
 
         val pageRequest = PageRequest.of(page, size)
         return messageRepository.findByChatIdPageable(chatId, pageRequest)

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import java.lang.Integer.max
 
 interface ChatService {
     fun createChat(userId: Long, sourceBoardId: Long, sourcePostId: Long, sourceReplyId: Long? = null, request: CreateChatRequest): CreateChatResponse

--- a/src/main/kotlin/com/wafflytime/exception/Exceptions.kt
+++ b/src/main/kotlin/com/wafflytime/exception/Exceptions.kt
@@ -11,3 +11,4 @@ open class BoardException(msg: String, errorCode: Int, status: HttpStatus) : Waf
 open class PostException(msg: String, errorCode: Int, status: HttpStatus) : WafflyTimeException(msg, 500 + errorCode, status)
 open class ReplyException(msg: String, errorCode: Int, status: HttpStatus) : WafflyTimeException(msg, 600 + errorCode, status)
 open class NotificationException(msg: String, errorCode: Int, status: HttpStatus) : WafflyTimeException(msg, 700 + errorCode, status)
+open class ChatException(msg: String, errorCode: Int, status: HttpStatus) : WafflyTimeException(msg, 800 + errorCode, status)

--- a/src/main/kotlin/com/wafflytime/reply/service/ReplyService.kt
+++ b/src/main/kotlin/com/wafflytime/reply/service/ReplyService.kt
@@ -115,6 +115,10 @@ class ReplyService(
         }
     }
 
+    fun getReplyEntity(postId: Long, replyId: Long): ReplyEntity {
+        return validatePostAndReply(postId, replyId)
+    }
+
     private fun commentCount(post: PostEntity): Long {
         return replyRepositorySupport.getLastReplyGroup(post)
     }


### PR DESCRIPTION
아래와 같이 생각하면서 구현했습니다!

1. 채팅의 아이덴티티
둘 다 익명이 아닌 경우, 양측의 유저 아이디만 같으면 같은 채팅으로 취급합니다.
둘중 한명이라도 익명인 경우, (1) 쪽지가 시작된 원 글 (2) 양측의 유저 아이디 (3) 양측의 익명 여부 (4) 쪽지를 시작한 사람 (엔티티에서는 participant1, 2의 순서에 해당)이 모두 같으면 같은 채팅으로 취급합니다.

2. 게시글/댓글을 통해 메세지를 보내는 경우
`createChat()`에 해당하는 동작입니다.
우선 같은 아이덴티티의 채팅이 존재하는지를 찾고 존재하는 경우 거기에 이어서 메세지를 보내고 아니면 새로 만듭니다.
새로 만드는 경우에는 출처를 밝혀주는 시스템 메세지를 가장 처음에 추가합니다.

3. 메세지를 보내는 경우
메세지를 보내는 요청이 성공하면 메세지 정보를 응답으로 돌려줍니다.
프론트에서는 이 응답을 바탕으로 보낸 메세지를 클라이언트에 저장해 놓습니다.

4. 메세지를 받는 경우
`chatEntity`의 `unread` 필드를 통해 안읽은 메세지가 몇개인지 확인 가능합니다.
`unread`만큼의 메세지를 읽어서 저장하거나 이전 기록이 남아있지 않다면 추가로 GET 메소드를 통해 가져옵니다.

5. 차단
양쪽 모두 차단이 가능하고 차단 칼럼이 양쪽모두에 존재합니다.
한쪽이라도 차단된 경우에는 메세지를 어느쪽에서 보내도 디비에 저장하지 않습니다.
보낸 측에게는 차단 여부 관계없이 돌아오는 응답이 똑같기 때문에 클라이언트에서는 보낸 메세지를 그대로 저장해 놓게 됩니다.