### PR TITLE
fix/oauth

### DIFF
--- a/src/main/kotlin/com/wafflytime/user/auth/dto/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflytime/user/auth/dto/SignUpRequest.kt
@@ -1,6 +1,7 @@
 package com.wafflytime.user.auth.dto
 
 import jakarta.validation.constraints.NotBlank
+import org.hibernate.validator.constraints.Length
 
 data class SignUpRequest(
     @field:NotBlank
@@ -8,5 +9,6 @@ data class SignUpRequest(
     @field:NotBlank
     val password: String,
     @field:NotBlank
+    @field:Length(min = 2, max = 10)
     val nickname: String,
 )

--- a/src/main/kotlin/com/wafflytime/user/info/dto/UpdateUserInfoRequest.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/dto/UpdateUserInfoRequest.kt
@@ -1,7 +1,10 @@
 package com.wafflytime.user.info.dto
 
+import org.hibernate.validator.constraints.Length
+
 data class UpdateUserInfoRequest(
     val oldPassword: String?,
     val newPassword: String?,
+    @field:Length(min = 2, max = 10)
     val nickname: String?,
 )


### PR DESCRIPTION
프론트 쪽에서 요청한 수정 사항 반영
- 가입되지 않은 소셜 이메일이면 임시 닉네임을 임의로 생성해서 회원가입하도록 수정
- 임시 닉네임 : temp-nickname-소셜 이메일 주소 (ex. temp-nickname-aaa@naver.com)

oauth 이외에 프론트 쪽에서 언급 나왔던 사항
- 닉네임 변경 30일 제한?
- 사용자 지정 닉네임(임시 닉네임은 해당 없음) 길이 제한 2자~10자
- 게시물 검색