### PR TITLE
Feature/realtime chat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,9 @@ dependencies {
 
 	// redis
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+	// websocket
+	implementation("org.springframework.boot:spring-boot-starter-websocket")
 }
 
 // QueryDSL

--- a/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
+++ b/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
@@ -23,15 +23,6 @@ class ChatController(
         return chatService.createChat(userId, boardId, postId, replyId, request)
     }
 
-    @PostMapping("/api/chat/{chatId}")
-    fun sendMessage(
-        @UserIdFromToken userId: Long,
-        @PathVariable chatId: Long,
-        @Valid @RequestBody request: SendMessageRequest,
-    ): MessageInfo {
-        return chatService.sendMessage(userId, chatId, request)
-    }
-
     @GetMapping("/api/chat")
     fun getChatList(
         @UserIdFromToken userId: Long,

--- a/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
+++ b/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
@@ -49,4 +49,13 @@ class ChatController(
         return chatService.updateChatBlock(userId, chatId, request)
     }
 
+    @PutMapping("/api/chat/unread")
+    fun updateChatUnread(
+        @UserIdFromToken userId: Long,
+        @Valid @RequestBody request: UpdateUnreadRequest,
+    ): String {
+        chatService.updateUnread(userId, request)
+        return "success"
+    }
+
 }

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
@@ -1,5 +1,6 @@
 package com.wafflytime.chat.database
 
+import com.wafflytime.chat.exception.UserChatMismatch
 import com.wafflytime.common.BaseTimeEntity
 import com.wafflytime.user.info.database.UserEntity
 import jakarta.persistence.*
@@ -39,7 +40,7 @@ class ChatEntity(
         return when (senderId) {
             participant1.id -> Pair(participant1, participant2)
             participant2.id -> Pair(participant2, participant1)
-            else -> throw TODO()
+            else -> throw UserChatMismatch
         }
     }
 

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatEntity.kt
@@ -35,4 +35,12 @@ class ChatEntity(
         }
     }
 
+    fun getSenderAndReceiver(senderId: Long): Pair<UserEntity, UserEntity> {
+        return when (senderId) {
+            participant1.id -> Pair(participant1, participant2)
+            participant2.id -> Pair(participant2, participant1)
+            else -> throw TODO()
+        }
+    }
+
 }

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
@@ -13,7 +13,8 @@ interface ChatRepository : JpaRepository<ChatEntity, Long>, ChatRepositorySuppor
 interface ChatRepositorySupport {
     fun findByParticipantIdWithLastMessage(userId: Long): List<ChatEntity>
     fun findByAllConditions(postId: Long, participantId1: Long, isAnonymous1: Boolean, participantId2: Long, isAnonymous2: Boolean) : ChatEntity?
-    fun findByBothParticipantId(participantId1: Long, participantId2: Long) : ChatEntity?
+    fun findByBothParticipantId(participantId1: Long, participantId2: Long): ChatEntity?
+    fun findByParticipantId(participantId: Long): List<ChatEntity>
 }
 
 @Repository
@@ -70,6 +71,16 @@ class ChatRepositorySupportImpl(
                     .and(chatEntity.isAnonymous2.isTrue)
             )
             .fetchOne()
+    }
+
+    override fun findByParticipantId(participantId: Long): List<ChatEntity> {
+        return jpaQueryFactory
+            .selectFrom(chatEntity)
+            .where(
+                chatEntity.participant1.id.eq(participantId)
+                    .or(chatEntity.participant2.id.eq(participantId))
+            )
+            .fetch()
     }
 
 }

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
@@ -65,10 +65,12 @@ class ChatRepositorySupportImpl(
         return jpaQueryFactory
             .selectFrom(chatEntity)
             .where(
-                chatEntity.participant1.id.eq(participantId1)
-                    .and(chatEntity.isAnonymous1.isTrue)
-                    .and(chatEntity.participant2.id.eq(participantId2))
+                chatEntity.isAnonymous1.isTrue
                     .and(chatEntity.isAnonymous2.isTrue)
+                    .and(
+                        (chatEntity.participant1.id.eq(participantId1).and(chatEntity.participant2.id.eq(participantId2)))
+                            .or(chatEntity.participant1.id.eq(participantId2).and(chatEntity.participant2.id.eq(participantId1)))
+                    )
             )
             .fetchOne()
     }

--- a/src/main/kotlin/com/wafflytime/chat/database/MessageEntity.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/MessageEntity.kt
@@ -18,6 +18,6 @@ class MessageEntity(
     @JoinColumn(name = "sender_id")
     val sender: UserEntity? = null, // null 인 경우 안내 메세지
     @field:NotBlank
-    val content: String,
+    val contents: String,
 ): BaseTimeEntity() {
 }

--- a/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
@@ -22,14 +22,14 @@ data class ChatSimpleInfo(
                 participant1.id -> ChatSimpleInfo(
                     id,
                     if (isAnonymous1) anonymousName else participant1.nickname,
-                    recentMessage.content,
+                    recentMessage.contents,
                     unread1,
                     blocked1,
                 )
                 participant2.id -> ChatSimpleInfo(
                     id,
                     if (isAnonymous2) anonymousName else participant2.nickname,
-                    recentMessage.content,
+                    recentMessage.contents,
                     unread2,
                     blocked2,
                 )

--- a/src/main/kotlin/com/wafflytime/chat/dto/CreateChatRequest.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/CreateChatRequest.kt
@@ -1,6 +1,9 @@
 package com.wafflytime.chat.dto
 
+import jakarta.validation.constraints.NotBlank
+
 data class CreateChatRequest(
     val isAnonymous: Boolean,
-    val content: String,
+    @field:NotBlank
+    val contents: String,
 )

--- a/src/main/kotlin/com/wafflytime/chat/dto/MessageInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/MessageInfo.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 data class MessageInfo(
     val sentAt: DateTimeResponse,
     val received: Boolean,
-    val content: String,
+    val contents: String,
 ) {
 
     companion object {

--- a/src/main/kotlin/com/wafflytime/chat/dto/MessageInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/MessageInfo.kt
@@ -16,7 +16,7 @@ data class MessageInfo(
             MessageInfo(
                 DateTimeResponse.of(createdAt ?: LocalDateTime.now()),
                 sender?.let { userId != it.id } ?: true,
-                content,
+                contents,
             )
         }
     }

--- a/src/main/kotlin/com/wafflytime/chat/dto/SendMessageRequest.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/SendMessageRequest.kt
@@ -1,8 +1,0 @@
-package com.wafflytime.chat.dto
-
-import jakarta.validation.constraints.NotBlank
-
-data class SendMessageRequest(
-    @NotBlank
-    val contents: String,
-)

--- a/src/main/kotlin/com/wafflytime/chat/dto/SendMessageRequest.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/SendMessageRequest.kt
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.NotBlank
 
 data class SendMessageRequest(
     @NotBlank
-    val content: String,
+    val contents: String,
 )

--- a/src/main/kotlin/com/wafflytime/chat/dto/UpdateUnreadRequest.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/UpdateUnreadRequest.kt
@@ -1,0 +1,6 @@
+package com.wafflytime.chat.dto
+
+data class UpdateUnreadRequest(
+    val chatId: List<Long>,
+    val unread: List<Int>,
+)

--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketChatCreationInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketChatCreationInfo.kt
@@ -1,0 +1,22 @@
+package com.wafflytime.chat.dto
+
+import com.wafflytime.chat.database.ChatEntity
+
+data class WebSocketChatCreationInfo(
+    val chatId: Long,
+    val target: String,
+    val type: WebSocketJsonType = WebSocketJsonType.NEWCHAT,
+) {
+
+    companion object {
+
+        private const val anonymousName = "익명"
+
+        fun of(entity: ChatEntity): WebSocketChatCreationInfo = entity.run {
+            WebSocketChatCreationInfo(
+                id,
+                if (isAnonymous2) anonymousName else participant2.nickname,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketClientMessage.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketClientMessage.kt
@@ -1,6 +1,6 @@
 package com.wafflytime.chat.dto
 
-data class WebSocketSendMessage(
+data class WebSocketClientMessage(
     val chatId: Long,
     val contents: String,
 ) {

--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketJsonType.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketJsonType.kt
@@ -1,0 +1,5 @@
+package com.wafflytime.chat.dto
+
+enum class WebSocketJsonType {
+    MESSAGE, NEWCHAT,
+}

--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketReceiveMessage.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketReceiveMessage.kt
@@ -1,0 +1,36 @@
+package com.wafflytime.chat.dto
+
+import com.wafflytime.chat.database.MessageEntity
+import com.wafflytime.common.DateTimeResponse
+import java.time.LocalDateTime
+
+data class WebSocketReceiveMessage(
+    val chatId: Long,
+    val sentAt: DateTimeResponse,
+    val received: Boolean,
+    val contents: String,
+) {
+
+    companion object {
+
+        fun of(userId: Long, entity: MessageEntity): WebSocketReceiveMessage = entity.run {
+            WebSocketReceiveMessage(
+                chat.id,
+                DateTimeResponse.of(createdAt ?: LocalDateTime.now()),
+                sender?.let { userId != it.id } ?: true,
+                contents,
+            )
+        }
+
+        fun senderAndReceiverPair(entity: MessageEntity): Pair<WebSocketReceiveMessage, WebSocketReceiveMessage> = entity.run {
+            val chatId = chat.id
+            val sentAt = DateTimeResponse.of(createdAt!!)
+            val contents = contents
+
+            Pair(
+                WebSocketReceiveMessage(chatId, sentAt, false, contents),
+                WebSocketReceiveMessage(chatId, sentAt, true, contents),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketSendMessage.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketSendMessage.kt
@@ -1,0 +1,8 @@
+package com.wafflytime.chat.dto
+
+data class WebSocketSendMessage(
+    val chatId: Long,
+    val contents: String,
+) {
+    constructor() : this(0, "")
+}

--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketServerMessage.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketServerMessage.kt
@@ -4,17 +4,18 @@ import com.wafflytime.chat.database.MessageEntity
 import com.wafflytime.common.DateTimeResponse
 import java.time.LocalDateTime
 
-data class WebSocketReceiveMessage(
+data class WebSocketServerMessage(
     val chatId: Long,
     val sentAt: DateTimeResponse,
     val received: Boolean,
     val contents: String,
+    val type: WebSocketJsonType = WebSocketJsonType.MESSAGE,
 ) {
 
     companion object {
 
-        fun of(userId: Long, entity: MessageEntity): WebSocketReceiveMessage = entity.run {
-            WebSocketReceiveMessage(
+        fun of(userId: Long, entity: MessageEntity): WebSocketServerMessage = entity.run {
+            WebSocketServerMessage(
                 chat.id,
                 DateTimeResponse.of(createdAt ?: LocalDateTime.now()),
                 sender?.let { userId != it.id } ?: true,
@@ -22,14 +23,14 @@ data class WebSocketReceiveMessage(
             )
         }
 
-        fun senderAndReceiverPair(entity: MessageEntity): Pair<WebSocketReceiveMessage, WebSocketReceiveMessage> = entity.run {
+        fun senderAndReceiverPair(entity: MessageEntity): Pair<WebSocketServerMessage, WebSocketServerMessage> = entity.run {
             val chatId = chat.id
             val sentAt = DateTimeResponse.of(createdAt!!)
             val contents = contents
 
             Pair(
-                WebSocketReceiveMessage(chatId, sentAt, false, contents),
-                WebSocketReceiveMessage(chatId, sentAt, true, contents),
+                WebSocketServerMessage(chatId, sentAt, false, contents),
+                WebSocketServerMessage(chatId, sentAt, true, contents),
             )
         }
     }

--- a/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
+++ b/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
@@ -9,9 +9,12 @@ open class Chat403(msg: String, errorCode: Int) : ChatException(msg, errorCode, 
 open class Chat404(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.NOT_FOUND)
 open class Chat409(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.CONFLICT)
 
+open class Chat500(msg: String, errorCode: Int) : ChatException(msg, errorCode, HttpStatus.INTERNAL_SERVER_ERROR)
+
 object ChatNotFound : Chat404("해당 id의 채팅을 찾을 수 없습니다", 0)
 object UserChatMismatch : Chat403("해당 유저가 속한 채팅이 아닙니다", 1)
 object NoMoreUnreadMessages : Chat400("안 읽은 메세지가 남아있지 않습니다", 2)
 object SelfChatForbidden : Chat400("자신에게 채팅을 보낼 수 없습니다", 3)
 object AlreadyBlocked : Chat400("이미 차단한 채팅입니다", 4)
 object AlreadyUnblocked : Chat400("이미 차단 해제한 채팅입니다", 5)
+object WebsocketAttributeError : Chat500("웹소켓 session attribute 문제", 6)

--- a/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
+++ b/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
@@ -17,4 +17,7 @@ object NoMoreUnreadMessages : Chat400("안 읽은 메세지가 남아있지 않�
 object SelfChatForbidden : Chat400("자신에게 채팅을 보낼 수 없습니다", 3)
 object AlreadyBlocked : Chat400("이미 차단한 채팅입니다", 4)
 object AlreadyUnblocked : Chat400("이미 차단 해제한 채팅입니다", 5)
-object WebsocketAttributeError : Chat500("웹소켓 session attribute 문제", 6)
+object ListLengthMismatch : Chat400("채팅 개수가 맞지 않습니다", 6)
+object ListMismatch : Chat400("채팅 목록이 일치하지 않습니다", 7)
+
+object WebsocketAttributeError : Chat500("웹소켓 session attribute 문제", 99)

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Service
 
 interface ChatService {
     fun createChat(userId: Long, sourceBoardId: Long, sourcePostId: Long, sourceReplyId: Long? = null, request: CreateChatRequest): CreateChatResponse
-    fun sendMessage(userId: Long, chatId: Long, request: SendMessageRequest): MessageInfo
     fun getChats(userId: Long): List<ChatSimpleInfo>
     fun getMessages(userId: Long, chatId: Long, page: Int, size: Int?): Page<MessageInfo>
     fun updateChatBlock(userId: Long, chatId: Long, request: UpdateChatBlockRequest): ChatSimpleInfo
@@ -105,16 +104,6 @@ class ChatServiceImpl(
         )
     }
 
-    @Transactional
-    override fun sendMessage(userId: Long, chatId: Long, request: SendMessageRequest): MessageInfo {
-        val user = userService.getUser(userId)
-        val chat = getChatEntity(chatId)
-        validateChatParticipant(user, chat)
-
-        val message = sendMessage(chat, user, request.contents)
-
-        return MessageInfo.of(userId, message)
-    }
 
     @Transactional
     override fun getChats(userId: Long): List<ChatSimpleInfo> {
@@ -199,11 +188,6 @@ class ChatServiceImpl(
             "${post.board.title}에 작성된 ${if (reply.isWriterAnonymous) "익명"+reply.anonymousId else reply.writer.nickname}의 댓글을 통해 시작된 쪽지입니다.\n" +
                     "글 내용: ${post.title ?: post.contents}"
         }
-    }
-
-    private fun validateChatParticipant(user: UserEntity, chat: ChatEntity) {
-        if (chat.participant1 != user && chat.participant2 != user)
-            throw UserChatMismatch
     }
 
 }

--- a/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
@@ -54,7 +54,7 @@ class WebSocketServiceImpl(
             session.close(CloseStatus(4900, e.message))
             return
         }
-        if (expiration > LocalDateTime.now()) {
+        if (expiration < LocalDateTime.now()) {
             session.close(CloseStatus(4901, "토큰 인증시간 만료"))
             return
         }

--- a/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
@@ -1,0 +1,84 @@
+package com.wafflytime.chat.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.wafflytime.chat.database.MessageEntity
+import com.wafflytime.chat.dto.WebSocketReceiveMessage
+import com.wafflytime.chat.dto.WebSocketSendMessage
+import org.springframework.stereotype.Service
+import org.springframework.web.socket.CloseStatus
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import java.time.LocalDateTime
+
+interface WebSocketService {
+    fun addSession(session: WebSocketSession)
+    fun removeSession(session: WebSocketSession)
+    fun sendMessage(session: WebSocketSession, message: TextMessage)
+}
+
+@Service
+class WebSocketServiceImpl(
+    private val chatService: ChatService,
+) : WebSocketService {
+
+    private val webSocketSessions: MutableMap<Long, WebSocketSession> = mutableMapOf()
+    private val objectMapper: ObjectMapper = ObjectMapper()
+
+    override fun addSession(session: WebSocketSession) {
+        webSocketSessions[userIdFromAttribute(session)] = session
+    }
+
+    override fun removeSession(session: WebSocketSession) {
+        webSocketSessions.remove(userIdFromAttribute(session))
+    }
+
+    override fun sendMessage(session: WebSocketSession, message: TextMessage) {
+        if (jwtExpirationFromAttribute(session) > LocalDateTime.now()) {
+            session.close(CloseStatus(9900, "토큰 인증시간 만료"))
+            return
+        }
+
+        val userId = userIdFromAttribute(session)
+        val (chatId, contents) = convertToJson(message)
+        val chat = chatService.getChatEntity(chatId)
+        val (sender, receiver) = chat.getSenderAndReceiver(userId)
+
+        val messageEntity = MessageEntity(chat, sender, contents)
+
+        if (!chat.isBlocked()) {
+            val (toSender, toReceiver) = WebSocketReceiveMessage.senderAndReceiverPair(
+                chatService.saveMessage(chat, messageEntity)
+            )
+
+            session.sendMessage(
+                convertToTextMessage(toSender)
+            )
+            webSocketSessions[receiver.id]?.sendMessage(
+                convertToTextMessage(toReceiver)
+            )
+        } else {
+            session.sendMessage(
+                convertToTextMessage(WebSocketReceiveMessage.of(userId, messageEntity))
+            )
+        }
+    }
+
+    private fun userIdFromAttribute(session: WebSocketSession): Long {
+        return session.attributes["UserIdFromToken"] as? Long
+            ?: throw TODO()
+    }
+
+    private fun jwtExpirationFromAttribute(session: WebSocketSession): LocalDateTime {
+        return session.attributes["JwtExpiration"] as? LocalDateTime
+            ?: throw TODO()
+    }
+
+    private fun convertToJson(message: TextMessage): WebSocketSendMessage {
+        return objectMapper.readValue(message.payload, WebSocketSendMessage::class.java)
+    }
+
+    private fun convertToTextMessage(messageInfo: WebSocketReceiveMessage): TextMessage {
+        return TextMessage(objectMapper.writeValueAsString(messageInfo))
+    }
+
+}

--- a/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
@@ -51,18 +51,18 @@ class WebSocketServiceImpl(
         val expiration = try {
             jwtExpirationFromAttribute(session)
         } catch (e: WebsocketAttributeError) {
-            session.close(CloseStatus(9900, e.message))
+            session.close(CloseStatus(4900, e.message))
             return
         }
-        if (expiration < LocalDateTime.now()) {
-            session.close(CloseStatus(9901, "토큰 인증시간 만료"))
+        if (expiration > LocalDateTime.now()) {
+            session.close(CloseStatus(4901, "토큰 인증시간 만료"))
             return
         }
 
         val userId = try {
             userIdFromAttribute(session)
         } catch (e: WebsocketAttributeError) {
-            session.close(CloseStatus(9900, e.message))
+            session.close(CloseStatus(4900, e.message))
             return
         }
         val (chatId, contents) = convertToJson(message)
@@ -70,7 +70,7 @@ class WebSocketServiceImpl(
         val (sender, receiver) = try {
             chat.getSenderAndReceiver(userId)
         } catch (e: UserChatMismatch) {
-            session.close(CloseStatus(9902, e.message))
+            session.close(CloseStatus(4902, e.message))
             return
         }
 

--- a/src/main/kotlin/com/wafflytime/config/WebSocketConfiguration.kt
+++ b/src/main/kotlin/com/wafflytime/config/WebSocketConfiguration.kt
@@ -1,0 +1,81 @@
+package com.wafflytime.config
+
+import com.wafflytime.chat.service.WebSocketService
+import com.wafflytime.user.auth.exception.AuthTokenNotProvided
+import com.wafflytime.user.auth.service.AuthTokenService
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.CloseStatus
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketHandler
+import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.config.annotation.EnableWebSocket
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
+import org.springframework.web.socket.handler.TextWebSocketHandler
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor
+
+@Configuration
+@EnableWebSocket
+class WebSocketConfiguration(
+    private val wafflytimeWebSocketHandler: WafflytimeWebSocketHandler,
+    private val webSocketHandshakeInterceptor: WebSocketHandshakeInterceptor,
+) : WebSocketConfigurer {
+
+    override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
+        registry.addHandler(handler(), "/api/ws-connect")
+            .addInterceptors(webSocketHandshakeInterceptor)
+            .setAllowedOrigins("*")
+    }
+
+    @Bean
+    fun handler() = wafflytimeWebSocketHandler
+
+}
+
+@Component
+class WafflytimeWebSocketHandler(
+    private val webSocketService: WebSocketService
+) : TextWebSocketHandler() {
+
+    override fun afterConnectionEstablished(session: WebSocketSession) {
+        webSocketService.addSession(session)
+        super.afterConnectionEstablished(session)
+    }
+
+    override fun handleTextMessage(session: WebSocketSession, message: TextMessage) {
+        webSocketService.sendMessage(session, message)
+        super.handleTextMessage(session, message)
+    }
+
+    override fun afterConnectionClosed(session: WebSocketSession, status: CloseStatus) {
+        webSocketService.removeSession(session)
+        super.afterConnectionClosed(session, status)
+    }
+
+}
+
+@Configuration
+class WebSocketHandshakeInterceptor(
+    private val authTokenService: AuthTokenService,
+) : HttpSessionHandshakeInterceptor() {
+
+    override fun beforeHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        attributes: MutableMap<String, Any>
+    ): Boolean {
+        val accessToken = request.headers["Authorization"]?.first() ?: throw AuthTokenNotProvided
+
+        val authResult = authTokenService.authenticate(accessToken)
+        attributes["UserIdFromToken"] = authTokenService.getUserId(authResult)
+        attributes["JwtExpiration"] = authTokenService.getExpiration(authResult)
+
+        return super.beforeHandshake(request, response, wsHandler, attributes)
+    }
+
+}

--- a/src/main/kotlin/com/wafflytime/notification/dto/Notification.kt
+++ b/src/main/kotlin/com/wafflytime/notification/dto/Notification.kt
@@ -1,5 +1,6 @@
 package com.wafflytime.notification.dto
 
+import com.wafflytime.chat.database.MessageEntity
 import com.wafflytime.notification.type.NotificationType
 import com.wafflytime.post.database.PostEntity
 import com.wafflytime.reply.database.ReplyEntity
@@ -16,6 +17,7 @@ data class NotificationInfo (
     constructor() : this(null, null, null, null)
 
     companion object {
+
         fun fromReply(post: PostEntity) : NotificationInfo {
             return NotificationInfo(
                 boardId = post.board.id,
@@ -23,6 +25,13 @@ data class NotificationInfo (
                 postId = post.id
             )
         }
+
+        fun fromMessage(message: MessageEntity) : NotificationInfo {
+            return NotificationInfo(
+                chatId = message.chat.id
+            )
+        }
+
     }
 }
 
@@ -33,7 +42,9 @@ data class NotificationDto (
     val contentCreatedAt: LocalDateTime?,
     val notificationInfo: NotificationInfo
 ) {
+
     companion object {
+
         fun fromReply(receiver: UserEntity, reply: ReplyEntity) : NotificationDto {
             return NotificationDto(
                 notificationType = NotificationType.REPLY,
@@ -43,5 +54,16 @@ data class NotificationDto (
                 notificationInfo = NotificationInfo.fromReply(reply.post)
             )
         }
+
+        fun fromMessage(receiver: UserEntity, message: MessageEntity) : NotificationDto {
+            return NotificationDto(
+                notificationType = NotificationType.MESSAGE,
+                receiver = receiver,
+                content = NotificationType.MESSAGE.prefix + message.contents,
+                contentCreatedAt = message.createdAt,
+                notificationInfo = NotificationInfo.fromMessage(message)
+            )
+        }
+
     }
 }

--- a/src/main/kotlin/com/wafflytime/user/auth/service/AuthTokenService.kt
+++ b/src/main/kotlin/com/wafflytime/user/auth/service/AuthTokenService.kt
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service
 import java.security.Key
 import java.sql.Timestamp
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 @ConfigurationProperties("auth.jwt")
 data class AuthProperties @ConstructorBinding constructor(
@@ -35,6 +36,7 @@ interface AuthTokenService {
     fun authenticate(accessToken: String): Jws<Claims>
     fun getUserId(authResult: Jws<Claims>): Long
     fun isEmailVerified(authResult: Jws<Claims>): Boolean
+    fun getExpiration(authResult: Jws<Claims>): LocalDateTime
 }
 
 @Service
@@ -94,6 +96,13 @@ class AuthTokenServiceImpl(
         return authResult.body.get("email-verified", String::class.java)
             ?.toBoolean()
             ?: throw InvalidAuthToken
+    }
+
+    override fun getExpiration(authResult: Jws<Claims>): LocalDateTime {
+        return authResult.body.expiration
+            .toInstant()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime()
     }
 
     private fun buildAuthToken(userId: Long, now: LocalDateTime, emailVerified: Boolean): AuthToken {


### PR DESCRIPTION
우선, 처음에는 STOMP 프로토콜을 사용하겠다고 했었는데
spring에서 자체적으로 지원해 주는 건 좋은데
(1) 커스텀하기가 어렵고 (자료가 별로 없습니다 ㅜㅜ) (2) 테스트하기가 매우 번거로워서
핸들러와 인터셉터로 구현했습니다

간단하게 설명하자면,

1. 웹소켓은 처음 연결할 때 (handshake) 사용하는 하나의 rest api만이 존재하는데, 이 handler는 기존에 저희가 사용하던 것들과는 `Interceptor`와 `MethodArgumentResolver`를 공유하지 않아 토큰을 파싱하고 필요한 값을 웹소켓 세션의 attribute에 따로 넣어줬습니다.
2. 기본적으로 쪽지를 바탕으로 추가 구현하는 것이기 때문에, 디비 사용하는 것을 유지하고, 채팅방 페이지로 넘어갈 때,
유저가 속한 채팅방 목록 요청 -> 웹소켓 연결 요청 순으로 요청하게하고,
각 채팅방에 들어갈 때도 이전 메시지 기록이 없다면 해당 채팅방 메시지 목록도 추가로 요청하고 웹소켓을 통해 오고가는 메세지들을 추가로 디스플레이 해나아가도록 하자고 생각하면서 구현했습니다
3. 웹소켓의 sub-protocol은 앞서 말씀드린 것처럼 STOMP를 사용하지 않고 기본적으로 Json 형태로 text를 주고 받도록 구현 했습니다.
client에서 서버로 메세지를 보낼 때는 `WebSocketClientMessage`의 형태의 json을 사용하고,
서버에서 client로 메세지를 보낼 때는 `WebSocketServerMessage` 혹은 `WebSocketChatCreationInfo`의 형태의 json을 사용합니다. 여기서 전자는 일반적인 메세지가 왔을 때 보내 주는 것이고, 후자는 새로운 채팅방이 생성됐을 때 이것이 웹에 실시간으로 적용되도록 그 정보를 보내 주는 것입니다.
4. 메세지가 웹소켓 세션을 통해 왔을 때 해당 메세지를 보내줘야 하는 상대 session은 `MutableMap`에 `userId`를 key로 저장해 놓은 session들을 통해서 찾습니다.


테스트는 postman의 WebSocket Request (Beta)를 활용해 해볼 수 있고, 이 때 다른 rest api와 마찬가지로 header에 `Authorization: Bearer <accessToken>`을 넣어줘야 합니다.

추가로 고민중인게,
웹소켓을 핸들러를 이용해서 구현할 때는 세션들을 자동으로 서버측에서 놓아주지 않아 계속 연결되어있는 세션이 많은 경우 메모리를 많이 잡아먹게 된다는 것입니다.
현재 구현에서는 세션으로 메세지가 왔을 때 handshake시에 넣어놓은 토큰의 만료시간이 지난 경우에만 서버 측에서 연결을 끊기 때문에, 프론트 측에서 활동이 어느 정도 시간동안 없는 경우 자동으로 disconnect하게 할 수 밖에 없는데, 이부분을 서버에서 처리할 수 있는지는 좀 더 따로 찾아봐야 할 것 같습니다.
또 하나, 현재 구현으로는 한 유저가 하나의 웹소켓 세션밖에 가지지 못하는데 이를 여러개가 가능하도록 허용해야 할지 고민입니다.

\+ sockjs fallback은 cors origin을 전체로 세팅해서 설정안했습니다.