### PR TITLE
Fix/realtime chat

### DIFF
--- a/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
@@ -65,8 +65,8 @@ class ChatRepositorySupportImpl(
         return jpaQueryFactory
             .selectFrom(chatEntity)
             .where(
-                chatEntity.isAnonymous1.isTrue
-                    .and(chatEntity.isAnonymous2.isTrue)
+                chatEntity.isAnonymous1.isFalse
+                    .and(chatEntity.isAnonymous2.isFalse)
                     .and(
                         (chatEntity.participant1.id.eq(participantId1).and(chatEntity.participant2.id.eq(participantId2)))
                             .or(chatEntity.participant1.id.eq(participantId2).and(chatEntity.participant2.id.eq(participantId1)))

--- a/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
@@ -21,14 +21,14 @@ data class ChatSimpleInfo(
             when (userId) {
                 participant1.id -> ChatSimpleInfo(
                     id,
-                    if (isAnonymous1) anonymousName else participant1.nickname,
+                    if (isAnonymous2) anonymousName else participant2.nickname,
                     recentMessage.contents,
                     unread1,
                     blocked1,
                 )
                 participant2.id -> ChatSimpleInfo(
                     id,
-                    if (isAnonymous2) anonymousName else participant2.nickname,
+                    if (isAnonymous1) anonymousName else participant1.nickname,
                     recentMessage.contents,
                     unread2,
                     blocked2,

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -96,7 +96,7 @@ class ChatServiceImpl(
 
         val firstMessage = sendMessage(chat, user, request.contents)
 
-        webSocketService.sendCreateChatResponse(chat, systemMessage, firstMessage)
+        webSocketService.sendCreateChatResponse(userId, chat, systemMessage, firstMessage)
 
         return CreateChatResponse(
             systemMessage != null,

--- a/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
@@ -48,16 +48,7 @@ class WebSocketServiceImpl(
 
     @Transactional
     override fun sendMessage(session: WebSocketSession, message: TextMessage) {
-        val expiration = try {
-            jwtExpirationFromAttribute(session)
-        } catch (e: WebsocketAttributeError) {
-            session.close(CloseStatus(4900, e.message))
-            return
-        }
-        if (expiration < LocalDateTime.now()) {
-            session.close(CloseStatus(4901, "토큰 인증시간 만료"))
-            return
-        }
+        if (!isSessionValid(session)) return
 
         val userId = try {
             userIdFromAttribute(session)
@@ -100,9 +91,11 @@ class WebSocketServiceImpl(
 
     @Transactional
     override fun sendCreateChatResponse(userId: Long, chat: ChatEntity, systemMessage: MessageEntity?, firstMessage: MessageEntity) {
+        val session1 = getWebSocketSession(chat.participant1.id)
+        val session2 = getWebSocketSession(chat.participant2.id)
         val (senderSession, receiverSession) = when (userId) {
-            chat.participant1.id -> Pair(webSocketSessions[chat.participant1.id], webSocketSessions[chat.participant2.id])
-            chat.participant2.id -> Pair(webSocketSessions[chat.participant2.id], webSocketSessions[chat.participant1.id])
+            chat.participant1.id -> Pair(session1, session2)
+            chat.participant2.id -> Pair(session2, session1)
             else -> throw UserChatMismatch
         }
 
@@ -133,6 +126,28 @@ class WebSocketServiceImpl(
                 NotificationDto.fromMessage(chat.participant2, firstMessage)
             )
         }
+    }
+
+    private fun getWebSocketSession(userId: Long): WebSocketSession? {
+        val session = webSocketSessions[userId]
+        session?.let { isSessionValid(it) }
+        return session
+    }
+
+    private fun isSessionValid(session: WebSocketSession): Boolean {
+        val expiration = try {
+            jwtExpirationFromAttribute(session)
+        } catch (e: WebsocketAttributeError) {
+            session.close(CloseStatus(4900, e.message))
+            return false
+        }
+
+        if (expiration < LocalDateTime.now()) {
+            session.close(CloseStatus(4901, "토큰 인증시간 만료"))
+            return false
+        }
+
+        return true
     }
 
     private fun userIdFromAttribute(session: WebSocketSession): Long {

--- a/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
@@ -75,7 +75,7 @@ class WebSocketServiceImpl(
             session.sendMessage(
                 convertToTextMessage(toSender)
             )
-            webSocketSessions[receiver.id]?.sendMessage(
+            getWebSocketSession(receiver.id)?.sendMessage(
                 convertToTextMessage(toReceiver)
             ) ?: run {
                 notificationService.send(


### PR DESCRIPTION
동작 이상했던 부분들 고쳤습니다!
* 둘다 익명이 아닐 때 같은 아이덴티티의 채팅을 찾는 쿼리에서 조건 잘못돼있던 것
* `ChatSimpleInfo`에서 target이 아니라 내 정보를 보여주고 있던 것
* 저번 pr에서 둘다 익명이 아닐 때 유저1,유저2와 일치할때와 유저2,유저1과 일치할때 둘다 확인하는 것으로 바꾸면서 웹소켓에 메세지 보낼 때도 변경사항 적용
* 메세지를 받을 때 토큰 유효시간이 끝났으면 웹소켓 세션을 끊도록 변경