### PR TITLE
feat: cursor based pagination

### DIFF
--- a/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
+++ b/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
@@ -2,9 +2,9 @@ package com.wafflytime.chat.api
 
 import com.wafflytime.chat.dto.*
 import com.wafflytime.chat.service.ChatService
+import com.wafflytime.common.CursorPage
 import com.wafflytime.config.UserIdFromToken
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -24,20 +24,30 @@ class ChatController(
     }
 
     @GetMapping("/api/chat")
+    fun getChat(
+        @UserIdFromToken userId: Long,
+        @RequestParam(required = true, value = "chatId") chatId: Long,
+    ): ChatSimpleInfo {
+        return chatService.getChat(userId, chatId)
+    }
+
+    @GetMapping("/api/chats")
     fun getChatList(
         @UserIdFromToken userId: Long,
-    ): List<ChatSimpleInfo> {
-        return chatService.getChats(userId)
+        @RequestParam(required = false, value = "cursor") cursor: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long,
+    ): CursorPage<ChatSimpleInfo> {
+        return chatService.getChats(userId, cursor, size)
     }
 
     @GetMapping("/api/chat/{chatId}/messages")
     fun getMessages(
         @UserIdFromToken userId: Long,
         @PathVariable chatId: Long,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size") size: Int?,
-    ): Page<MessageInfo> {
-        return chatService.getMessages(userId, chatId, page, size)
+        @RequestParam(required = false, value = "cursor") cursor: Long?,
+        @RequestParam(required = false, value = "size") size: Long?,
+    ): CursorPage<MessageInfo> {
+        return chatService.getMessages(userId, chatId, cursor, size)
     }
 
     @PutMapping("/api/chat/{chatId}")

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
@@ -3,6 +3,8 @@ package com.wafflytime.chat.database
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflytime.chat.database.QChatEntity.chatEntity
 import com.wafflytime.chat.database.QMessageEntity.messageEntity
+import com.wafflytime.chat.exception.ChatNotFound
+import com.wafflytime.common.CursorPage
 import com.wafflytime.user.info.database.QUserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
@@ -11,10 +13,11 @@ import org.springframework.stereotype.Repository
 interface ChatRepository : JpaRepository<ChatEntity, Long>, ChatRepositorySupport
 
 interface ChatRepositorySupport {
-    fun findByParticipantIdWithLastMessage(userId: Long): List<ChatEntity>
+    fun findByIdWithLastMessage(chatId: Long): ChatEntity?
+    fun findAllByParticipantIdWithLastMessage(userId: Long, cursor: Long?, size: Long): CursorPage<ChatEntity>
     fun findByAllConditions(postId: Long, participantId1: Long, isAnonymous1: Boolean, participantId2: Long, isAnonymous2: Boolean) : ChatEntity?
     fun findByBothParticipantId(participantId1: Long, participantId2: Long): ChatEntity?
-    fun findByParticipantId(participantId: Long): List<ChatEntity>
+    fun findAllByParticipantId(participantId: Long): List<ChatEntity>
 }
 
 @Repository
@@ -22,14 +25,42 @@ class ChatRepositorySupportImpl(
     private val jpaQueryFactory: JPAQueryFactory
 ) : QuerydslRepositorySupport(ChatEntity::class.java), ChatRepositorySupport {
 
-    override fun findByParticipantIdWithLastMessage(userId: Long): List<ChatEntity> {
+    override fun findByIdWithLastMessage(chatId: Long): ChatEntity? {
         val userEntity1 = QUserEntity("userEntity1")
         val userEntity2 = QUserEntity("userEntity2")
 
         return jpaQueryFactory
             .selectFrom(chatEntity)
+            .where(chatEntity.id.eq(chatId))
+            .leftJoin(chatEntity.messages, messageEntity)
+            .where(messageEntity.chat.id.eq(chatEntity.id))
+            .fetchJoin()
+            .leftJoin(chatEntity.participant1, userEntity1)
+            .where(userEntity1.id.eq(chatEntity.participant1.id))
+            .fetchJoin()
+            .leftJoin(chatEntity.participant2, userEntity2)
+            .where(userEntity2.id.eq(chatEntity.participant2.id))
+            .fetchJoin()
+            .fetchOne()
+    }
+
+    override fun findAllByParticipantIdWithLastMessage(userId: Long, cursor: Long?, size: Long): CursorPage<ChatEntity> {
+        val userEntity1 = QUserEntity("userEntity1")
+        val userEntity2 = QUserEntity("userEntity2")
+
+        val cursorEntity = jpaQueryFactory
+            .selectFrom(chatEntity)
+            .where(chatEntity.id.eq(cursor))
+            .fetchOne()
+            ?: throw ChatNotFound
+
+        val query = jpaQueryFactory
+            .selectFrom(chatEntity)
             .where(chatEntity.participant1.id.eq(userId).or(chatEntity.participant2.id.eq(userId)))
             .orderBy(chatEntity.modifiedAt.desc())
+
+        val result = (cursor?.let { query.where(chatEntity.modifiedAt.lt(cursorEntity.modifiedAt)) } ?: query)
+            .limit(size)
             .leftJoin(chatEntity.messages, messageEntity)
             .where(messageEntity.chat.id.eq(chatEntity.id))
             .fetchJoin()
@@ -40,6 +71,8 @@ class ChatRepositorySupportImpl(
             .where(userEntity2.id.eq(chatEntity.participant2.id))
             .fetchJoin()
             .fetch()
+
+        return CursorPage(result, result.lastOrNull()?.id, result.size.toLong())
     }
 
     override fun findByAllConditions(
@@ -75,7 +108,7 @@ class ChatRepositorySupportImpl(
             .fetchOne()
     }
 
-    override fun findByParticipantId(participantId: Long): List<ChatEntity> {
+    override fun findAllByParticipantId(participantId: Long): List<ChatEntity> {
         return jpaQueryFactory
             .selectFrom(chatEntity)
             .where(

--- a/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/ChatRepository.kt
@@ -48,18 +48,20 @@ class ChatRepositorySupportImpl(
         val userEntity1 = QUserEntity("userEntity1")
         val userEntity2 = QUserEntity("userEntity2")
 
-        val cursorEntity = jpaQueryFactory
-            .selectFrom(chatEntity)
-            .where(chatEntity.id.eq(cursor))
-            .fetchOne()
-            ?: throw ChatNotFound
+        val cursorEntity = cursor?.let {
+            jpaQueryFactory
+                .selectFrom(chatEntity)
+                .where(chatEntity.id.eq(it))
+                .fetchOne()
+                ?: throw ChatNotFound
+        }
 
         val query = jpaQueryFactory
             .selectFrom(chatEntity)
             .where(chatEntity.participant1.id.eq(userId).or(chatEntity.participant2.id.eq(userId)))
             .orderBy(chatEntity.modifiedAt.desc())
 
-        val result = (cursor?.let { query.where(chatEntity.modifiedAt.lt(cursorEntity.modifiedAt)) } ?: query)
+        val result = (cursorEntity?.let { query.where(chatEntity.modifiedAt.lt(it.modifiedAt)) } ?: query)
             .limit(size)
             .leftJoin(chatEntity.messages, messageEntity)
             .where(messageEntity.chat.id.eq(chatEntity.id))

--- a/src/main/kotlin/com/wafflytime/chat/database/MessageRepository.kt
+++ b/src/main/kotlin/com/wafflytime/chat/database/MessageRepository.kt
@@ -2,9 +2,7 @@ package com.wafflytime.chat.database
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflytime.chat.database.QMessageEntity.messageEntity
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
+import com.wafflytime.common.CursorPage
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.stereotype.Repository
@@ -12,7 +10,7 @@ import org.springframework.stereotype.Repository
 interface MessageRepository : JpaRepository<MessageEntity, Long>, MessageRepositorySupport
 
 interface MessageRepositorySupport {
-    fun findByChatIdPageable(chatId: Long, pageable: Pageable): Page<MessageEntity>
+    fun findByChatIdPageable(chatId: Long, cursor: Long?, size: Long): CursorPage<MessageEntity>
 }
 
 @Repository
@@ -20,20 +18,18 @@ class MessageRepositorySupportImpl(
     private val jpaQueryFactory: JPAQueryFactory
 ) : QuerydslRepositorySupport(MessageEntity::class.java), MessageRepositorySupport {
 
-    override fun findByChatIdPageable(chatId: Long, pageable: Pageable): Page<MessageEntity> {
+    override fun findByChatIdPageable(chatId: Long, cursor: Long?, size: Long): CursorPage<MessageEntity> {
         val query = jpaQueryFactory
             .selectFrom(messageEntity)
             .where(messageEntity.chat.id.eq(chatId))
+            .orderBy(messageEntity.id.desc())
 
-        val count = query.fetch().size.toLong()
-        val result = query
-            .orderBy(messageEntity.createdAt.desc())
-            .offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
+        val result = (cursor?.let { query.where(messageEntity.id.lt(it)) } ?: query)
+            .limit(size)
             .fetch()
             .reversed()
 
-        return PageImpl(result, pageable, count)
+        return CursorPage(result, result.firstOrNull()?.id, result.size.toLong())
     }
 
 }

--- a/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/ChatSimpleInfo.kt
@@ -2,11 +2,13 @@ package com.wafflytime.chat.dto
 
 import com.wafflytime.chat.database.ChatEntity
 import com.wafflytime.chat.exception.UserChatMismatch
+import com.wafflytime.common.DateTimeResponse
 
 data class ChatSimpleInfo(
     val id: Long,
     val target: String,
     val recentMessage: String,
+    val recentTime: DateTimeResponse,
     val unread: Int,
     val blocked: Boolean,
 ) {
@@ -21,15 +23,17 @@ data class ChatSimpleInfo(
             when (userId) {
                 participant1.id -> ChatSimpleInfo(
                     id,
-                    if (isAnonymous1) anonymousName else participant1.nickname,
+                    if (isAnonymous2) anonymousName else participant2.nickname,
                     recentMessage.contents,
+                    DateTimeResponse.of(recentMessage.createdAt!!),
                     unread1,
                     blocked1,
                 )
                 participant2.id -> ChatSimpleInfo(
                     id,
-                    if (isAnonymous2) anonymousName else participant2.nickname,
+                    if (isAnonymous1) anonymousName else participant1.nickname,
                     recentMessage.contents,
+                    DateTimeResponse.of(recentMessage.createdAt!!),
                     unread2,
                     blocked2,
                 )

--- a/src/main/kotlin/com/wafflytime/common/CursorPage.kt
+++ b/src/main/kotlin/com/wafflytime/common/CursorPage.kt
@@ -1,0 +1,31 @@
+package com.wafflytime.common
+
+data class CursorPage<T>(
+    val contents: List<T>,
+    val cursor: Long?,
+    val size: Long,
+) {
+
+    inline fun <R> map(transform: (T) -> R): CursorPage<R> {
+        return CursorPage(
+            contents.map { transform(it) },
+            cursor,
+            size,
+        )
+    }
+}
+
+data class DoubleCursorPage<T>(
+    val contents: List<T>,
+    val cursor: Pair<Long, Long>?,
+    val size: Long,
+) {
+
+    inline fun <R> map(transform: (T) -> R): DoubleCursorPage<R> {
+        return DoubleCursorPage(
+            contents.map { transform(it) },
+            cursor,
+            size,
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflytime/exception/Exceptions.kt
+++ b/src/main/kotlin/com/wafflytime/exception/Exceptions.kt
@@ -12,3 +12,5 @@ open class PostException(msg: String, errorCode: Int, status: HttpStatus) : Waff
 open class ReplyException(msg: String, errorCode: Int, status: HttpStatus) : WafflyTimeException(msg, 600 + errorCode, status)
 open class NotificationException(msg: String, errorCode: Int, status: HttpStatus) : WafflyTimeException(msg, 700 + errorCode, status)
 open class ChatException(msg: String, errorCode: Int, status: HttpStatus) : WafflyTimeException(msg, 800 + errorCode, status)
+
+object DoubleCursorMismatch : WafflyTimeException("cursor 는 둘다 null 이거나 둘다 non-null 이어야 합니다", 4, HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/wafflytime/notification/database/NotificationRepository.kt
+++ b/src/main/kotlin/com/wafflytime/notification/database/NotificationRepository.kt
@@ -1,9 +1,33 @@
 package com.wafflytime.notification.database
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflytime.common.CursorPage
+import com.wafflytime.notification.database.QNotificationEntity.notificationEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
-interface NotificationRepository : JpaRepository<NotificationEntity, Long> {
-    fun findAllByReceiverId(userId: Long, pageable: Pageable) : Page<NotificationEntity>
+interface NotificationRepository : JpaRepository<NotificationEntity, Long>, NotificationRepositorySupport
+
+interface NotificationRepositorySupport {
+    fun findAllByReceiverId(userId: Long, cursor: Long?, size: Long): CursorPage<NotificationEntity>
+}
+
+@Repository
+class NotificationRepositorySupportImpl(
+    private val queryFactory: JPAQueryFactory,
+) : NotificationRepositorySupport {
+
+    override fun findAllByReceiverId(userId: Long, cursor: Long?, size: Long): CursorPage<NotificationEntity> {
+        val query = queryFactory
+            .selectFrom(notificationEntity)
+            .where(notificationEntity.receiver.id.eq(userId))
+            .orderBy(notificationEntity.id.desc())
+
+        val result = (cursor?.let { query.where(notificationEntity.id.lt(it)) } ?: query)
+            .limit(size)
+            .fetch()
+
+        return CursorPage(result, result.lastOrNull()?.id, result.size.toLong())
+    }
+
 }

--- a/src/main/kotlin/com/wafflytime/notification/database/NotificationRepository.kt
+++ b/src/main/kotlin/com/wafflytime/notification/database/NotificationRepository.kt
@@ -3,6 +3,7 @@ package com.wafflytime.notification.database
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflytime.common.CursorPage
 import com.wafflytime.notification.database.QNotificationEntity.notificationEntity
+import com.wafflytime.notification.type.NotificationType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
@@ -20,6 +21,7 @@ class NotificationRepositorySupportImpl(
     override fun findAllByReceiverId(userId: Long, cursor: Long?, size: Long): CursorPage<NotificationEntity> {
         val query = queryFactory
             .selectFrom(notificationEntity)
+            .where(!notificationEntity.notificationType.eq(NotificationType.MESSAGE))
             .where(notificationEntity.receiver.id.eq(userId))
             .orderBy(notificationEntity.id.desc())
 

--- a/src/main/kotlin/com/wafflytime/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/wafflytime/notification/service/NotificationService.kt
@@ -1,5 +1,6 @@
 package com.wafflytime.notification.service
 
+import com.wafflytime.common.CursorPage
 import com.wafflytime.notification.database.EmitterRepository
 import com.wafflytime.notification.database.NotificationEntity
 import com.wafflytime.notification.database.NotificationRepository
@@ -9,9 +10,6 @@ import com.wafflytime.notification.dto.NotificationResponse
 import com.wafflytime.notification.exception.NotificationNotFound
 import jakarta.transaction.Transactional
 import org.apache.catalina.connector.ClientAbortException
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -97,9 +95,10 @@ class NotificationService(
         return CheckNotificationResponse(notificationId)
     }
 
-    fun getNotifications(userId: Long, page: Int, size: Int): Page<NotificationResponse> {
-        return notificationRepository.findAllByReceiverId(
-            userId, PageRequest.of(page, size,  Sort.by(Sort.Direction.DESC, "createdAt"))
-        ).map { NotificationResponse.of(it) }
+    fun getNotifications(userId: Long, cursor: Long?, size: Long): CursorPage<NotificationResponse> {
+        return notificationRepository.findAllByReceiverId(userId, cursor, size).map {
+            NotificationResponse.of(it)
+        }
     }
+
 }

--- a/src/main/kotlin/com/wafflytime/post/api/PostController.kt
+++ b/src/main/kotlin/com/wafflytime/post/api/PostController.kt
@@ -2,11 +2,12 @@ package com.wafflytime.post.api
 
 import com.wafflytime.board.dto.*
 import com.wafflytime.board.type.BoardCategory
+import com.wafflytime.common.CursorPage
+import com.wafflytime.common.DoubleCursorPage
 import com.wafflytime.config.UserIdFromToken
 import com.wafflytime.post.dto.*
 import com.wafflytime.post.service.PostService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -28,10 +29,10 @@ class PostController(
     fun getPosts(
         @UserIdFromToken userId: Long,
         @PathVariable boardId: Long,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size", defaultValue = "20") size: Int
-    ) : ResponseEntity<Page<PostResponse>> {
-        return ResponseEntity.ok(postService.getPosts(userId, boardId, page, size))
+        @RequestParam(required = false, value = "cursor") cursor: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
+    ) : ResponseEntity<CursorPage<PostResponse>> {
+        return ResponseEntity.ok(postService.getPosts(userId, boardId, cursor, size))
     }
 
     @PostMapping("/api/board/{boardId}/post")
@@ -84,29 +85,30 @@ class PostController(
     @GetMapping("/api/hotpost")
     fun getHotPost(
         @UserIdFromToken userId: Long,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size", defaultValue = "20") size: Int
-    ) : ResponseEntity<Page<PostResponse>> {
-        return ResponseEntity.ok(postService.getHostPosts(userId, page, size))
+        @RequestParam(required = false, value = "cursor") cursor: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
+    ) : ResponseEntity<CursorPage<PostResponse>> {
+        return ResponseEntity.ok(postService.getHotPosts(userId, cursor, size))
     }
 
     @GetMapping("/api/bestpost")
     fun getBestPost(
         @UserIdFromToken userId: Long,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size", defaultValue = "20") size: Int
-    ) : ResponseEntity<Page<PostResponse>> {
-        return ResponseEntity.ok(postService.getBestPosts(userId, page, size))
+        @RequestParam(required = false, value = "first") first: Long?,
+        @RequestParam(required = false, value = "second") second: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
+    ) : ResponseEntity<DoubleCursorPage<PostResponse>> {
+        return ResponseEntity.ok(postService.getBestPosts(userId, first, second, size))
     }
 
     @GetMapping("/api/posts/search")
-    fun searchBoards(
+    fun searchPosts(
         @UserIdFromToken userId: Long,
         @RequestParam(required = true, value = "keyword") keyword: String,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size", defaultValue = "20") size: Int
-    ) : ResponseEntity<Page<PostResponse>> {
-        return ResponseEntity.ok(postService.searchPosts(userId, keyword, page, size))
+        @RequestParam(required = false, value = "cursor") cursor: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
+    ) : ResponseEntity<CursorPage<PostResponse>> {
+        return ResponseEntity.ok(postService.searchPosts(userId, keyword, cursor, size))
     }
 
     @GetMapping("/api/homeposts")

--- a/src/main/kotlin/com/wafflytime/post/database/PostRepository.kt
+++ b/src/main/kotlin/com/wafflytime/post/database/PostRepository.kt
@@ -54,7 +54,7 @@ class PostRepositorySupportImpl(
             (cursor?.run {
                 query
                     .where(postEntity.nLikes.loe(first.toInt()))
-                    .where(postEntity.nLikes.eq(first.toInt()).and(postEntity.id.lt(second)))
+                    .where(postEntity.nLikes.lt(first.toInt()).or(postEntity.id.lt(second)))
             } ?: query)
                 .limit(size)
                 .fetch()

--- a/src/main/kotlin/com/wafflytime/reply/api/ReplyController.kt
+++ b/src/main/kotlin/com/wafflytime/reply/api/ReplyController.kt
@@ -1,12 +1,12 @@
 package com.wafflytime.reply.api
 
+import com.wafflytime.common.DoubleCursorPage
 import com.wafflytime.reply.dto.CreateReplyRequest
 import com.wafflytime.reply.dto.ReplyResponse
 import com.wafflytime.reply.dto.UpdateReplyRequest
 import com.wafflytime.reply.service.ReplyService
 import com.wafflytime.config.UserIdFromToken
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -59,10 +59,11 @@ class ReplyController(
     fun getReplies(
         @PathVariable boardId: Long,
         @PathVariable postId: Long,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size", defaultValue = "20") size: Int,
-    ) : ResponseEntity<Page<ReplyResponse>>{
-        return ResponseEntity.ok(replyService.getReplies(boardId, postId, page, size))
+        @RequestParam(required = false, value = "first") first: Long?,
+        @RequestParam(required = false, value = "second") second: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long,
+    ) : ResponseEntity<DoubleCursorPage<ReplyResponse>>{
+        return ResponseEntity.ok(replyService.getReplies(boardId, postId, first, second, size))
     }
 
     @PostMapping("/api/board/{boardId}/post/{postId}/reply/{replyId}/like")

--- a/src/main/kotlin/com/wafflytime/reply/api/ReplyController.kt
+++ b/src/main/kotlin/com/wafflytime/reply/api/ReplyController.kt
@@ -65,7 +65,7 @@ class ReplyController(
         @RequestParam(required = false, value = "second") second: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long,
     ) : ResponseEntity<DoubleCursorPage<ReplyResponse>>{
-        return ResponseEntity.ok(replyService.getReplies(boardId, postId, first, second, size))
+        return ResponseEntity.ok(replyService.getReplies(userId, boardId, postId, first, second, size))
     }
 
     @PostMapping("/api/board/{boardId}/post/{postId}/reply/{replyId}/like")

--- a/src/main/kotlin/com/wafflytime/reply/service/ReplyService.kt
+++ b/src/main/kotlin/com/wafflytime/reply/service/ReplyService.kt
@@ -113,13 +113,13 @@ class ReplyService(
         return replyToResponse(userId, reply)
     }
 
-    fun getReplies(boardId: Long, postId: Long, first: Long?, second: Long?, size: Long): DoubleCursorPage<ReplyResponse> {
+    fun getReplies(userId: Long, boardId: Long, postId: Long, first: Long?, second: Long?, size: Long): DoubleCursorPage<ReplyResponse> {
         val post = postService.validateBoardAndPost(boardId, postId)
         if ((first == null) != (second == null)) throw DoubleCursorMismatch
         val cursor = first?.let { Pair(it, second!!) }
 
         return replyRepositorySupport.getReplies(post, cursor, size).map {
-            replyToResponse(it)
+            replyToResponse(userId, it)
         }
     }
 

--- a/src/main/kotlin/com/wafflytime/reply/service/ReplyService.kt
+++ b/src/main/kotlin/com/wafflytime/reply/service/ReplyService.kt
@@ -1,7 +1,10 @@
 package com.wafflytime.reply.service
 
+import com.wafflytime.common.CursorPage
 import com.wafflytime.common.DateTimeResponse
+import com.wafflytime.common.DoubleCursorPage
 import com.wafflytime.common.RedisService
+import com.wafflytime.exception.DoubleCursorMismatch
 import com.wafflytime.notification.dto.NotificationDto
 import com.wafflytime.notification.service.NotificationService
 import com.wafflytime.post.database.PostEntity
@@ -110,10 +113,12 @@ class ReplyService(
         return replyToResponse(reply)
     }
 
-    fun getReplies(boardId: Long, postId: Long, page: Int, size: Int): Page<ReplyResponse> {
+    fun getReplies(boardId: Long, postId: Long, first: Long?, second: Long?, size: Long): DoubleCursorPage<ReplyResponse> {
         val post = postService.validateBoardAndPost(boardId, postId)
-        val pageRequest = PageRequest.of(page, size)
-        return replyRepositorySupport.getReplies(post, pageRequest).map {
+        if ((first == null) != (second == null)) throw DoubleCursorMismatch
+        val cursor = first?.let { Pair(it, second!!) }
+
+        return replyRepositorySupport.getReplies(post, cursor, size).map {
             replyToResponse(it)
         }
     }

--- a/src/main/kotlin/com/wafflytime/user/info/api/UserController.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/api/UserController.kt
@@ -1,5 +1,6 @@
 package com.wafflytime.user.info.api
 
+import com.wafflytime.common.CursorPage
 import com.wafflytime.config.ExemptAuthentication
 import com.wafflytime.config.ExemptEmailVerification
 import com.wafflytime.config.UserIdFromToken
@@ -12,7 +13,6 @@ import com.wafflytime.user.info.dto.UploadProfileImageRequest
 import com.wafflytime.user.info.dto.UserInfo
 import com.wafflytime.user.info.service.UserService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -68,10 +68,10 @@ class UserController(
     @GetMapping("/api/user/myscrap")
     fun getMyScraps(
         @UserIdFromToken userId: Long,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size", defaultValue = "20") size: Int
-    ): ResponseEntity<Page<PostResponse>> {
-        return ResponseEntity.ok(userService.getMyScraps(userId, page, size))
+        @RequestParam(required = false, value = "cursor") cursor: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
+    ): ResponseEntity<CursorPage<PostResponse>> {
+        return ResponseEntity.ok(userService.getMyScraps(userId, cursor, size))
     }
 
     @DeleteMapping("/api/user/myscrap")
@@ -85,18 +85,18 @@ class UserController(
     @GetMapping("/api/user/mypost")
     fun getMyPosts(
         @UserIdFromToken userId: Long,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size", defaultValue = "20") size: Int
-    ) : ResponseEntity<Page<PostResponse>> {
-        return ResponseEntity.ok(userService.getMyPosts(userId, page, size))
+        @RequestParam(required = false, value = "cursor") cursor: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
+    ) : ResponseEntity<CursorPage<PostResponse>> {
+        return ResponseEntity.ok(userService.getMyPosts(userId, cursor, size))
     }
 
     @GetMapping("/api/user/notifications")
     fun getNotifications(
         @UserIdFromToken userId: Long,
-        @RequestParam(required = false, value = "page", defaultValue = "0") page: Int,
-        @RequestParam(required = false, value = "size", defaultValue = "20") size: Int
-    ) : ResponseEntity<Page<NotificationResponse>> {
-        return ResponseEntity.ok(notificationService.getNotifications(userId, page, size))
+        @RequestParam(required = false, value = "cursor") cursor: Long?,
+        @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
+    ) : ResponseEntity<CursorPage<NotificationResponse>> {
+        return ResponseEntity.ok(notificationService.getNotifications(userId, cursor, size))
     }
 }

--- a/src/main/kotlin/com/wafflytime/user/info/service/UserService.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/service/UserService.kt
@@ -1,5 +1,6 @@
 package com.wafflytime.user.info.service
 
+import com.wafflytime.common.CursorPage
 import com.wafflytime.common.S3Service
 import com.wafflytime.post.database.PostRepository
 import com.wafflytime.post.database.ScrapRepository
@@ -11,12 +12,8 @@ import com.wafflytime.user.info.dto.UpdateUserInfoRequest
 import com.wafflytime.user.info.dto.UploadProfileImageRequest
 import com.wafflytime.user.info.dto.UserInfo
 import com.wafflytime.user.info.exception.*
-import com.wafflytime.user.mail.dto.VerifyEmailRequest
 import jakarta.transaction.Transactional
 import org.springframework.dao.DataIntegrityViolationException
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -29,9 +26,9 @@ interface UserService {
     fun checkUnivEmailConflict(univEmail: String)
     fun updateUserInfo(userId: Long, request: UpdateUserInfoRequest): UserInfo
     fun updateUserMailVerified(userId: Long, email: String): UserEntity
-    fun getMyScraps(userId: Long, page:Int, size:Int): Page<PostResponse>
+    fun getMyScraps(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse>
     fun deleteScrap(userId: Long, postId: Long): DeleteScrapResponse
-    fun getMyPosts(userId: Long, page: Int, size: Int): Page<PostResponse>
+    fun getMyPosts(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse>
     fun updateProfileImage(userId: Long, request: UploadProfileImageRequest): UserInfo
     fun deleteProfileImage(userId: Long): UserInfo
 }
@@ -107,8 +104,8 @@ class UserServiceImpl (
         return user
     }
 
-    override fun getMyScraps(userId: Long, page:Int, size:Int): Page<PostResponse> {
-        return scrapRepository.findScrapsByUserId(userId, PageRequest.of(page, size)).map {
+    override fun getMyScraps(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse> {
+        return scrapRepository.findScrapsByUserId(userId, cursor, size).map {
             PostResponse.of(userId, it.post)
         }
     }
@@ -124,10 +121,8 @@ class UserServiceImpl (
         return DeleteScrapResponse(scrap.post.id)
     }
 
-    override fun getMyPosts(userId: Long, page: Int, size: Int): Page<PostResponse> {
-        return postRepository.findAllByWriterId(
-            userId, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
-        ).map {
+    override fun getMyPosts(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse> {
+        return postRepository.findAllByWriterId(userId, cursor, size).map {
             PostResponse.of(userId, it)
         }
     }


### PR DESCRIPTION
* 커서 기반 페이지네이션으로 변경
* 댓글이나 베스트 게시물은 커서 조건이 두개 필요해 `DoubleCursorPage` 사용
(커서를 두개 사용해도 데이터가 아주 적지 않은 이상 더 효율적이라고 합니다)
* 채팅 목록도 페이지네이션 적용,
이에 따라 프론트에 정보가 없는 채팅에 웹소켓으로 쪽지가 왔을 때를 대비해 단일 채팅 정보 요청 추가

그리고 알림 목록에는 쪽지 알림은 안나오던데 이 조건도 쿼리에 추가할까요?