### PR TITLE
Fix/offset page

### DIFF
--- a/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
+++ b/src/main/kotlin/com/wafflytime/chat/api/ChatController.kt
@@ -34,20 +34,24 @@ class ChatController(
     @GetMapping("/api/chats")
     fun getChatList(
         @UserIdFromToken userId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long,
     ): CursorPage<ChatSimpleInfo> {
-        return chatService.getChats(userId, cursor, size)
+        return page?.let { chatService.getChats(userId, it, size) }
+            ?: chatService.getChats(userId, cursor, size)
     }
 
     @GetMapping("/api/chat/{chatId}/messages")
     fun getMessages(
         @UserIdFromToken userId: Long,
         @PathVariable chatId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size") size: Long?,
     ): CursorPage<MessageInfo> {
-        return chatService.getMessages(userId, chatId, cursor, size)
+        return page?.let { chatService.getMessages(userId, chatId, it, size) }
+            ?: chatService.getMessages(userId, chatId, cursor, size)
     }
 
     @PutMapping("/api/chat/{chatId}")

--- a/src/main/kotlin/com/wafflytime/common/CursorPage.kt
+++ b/src/main/kotlin/com/wafflytime/common/CursorPage.kt
@@ -2,13 +2,15 @@ package com.wafflytime.common
 
 data class CursorPage<T>(
     val contents: List<T>,
-    val cursor: Long?,
+    val page: Long? = null,
+    val cursor: Long? = null,
     val size: Long,
 ) {
 
     inline fun <R> map(transform: (T) -> R): CursorPage<R> {
         return CursorPage(
             contents.map { transform(it) },
+            page,
             cursor,
             size,
         )
@@ -17,13 +19,15 @@ data class CursorPage<T>(
 
 data class DoubleCursorPage<T>(
     val contents: List<T>,
-    val cursor: Pair<Long, Long>?,
+    val page: Long? = null,
+    val cursor: Pair<Long, Long>? = null,
     val size: Long,
 ) {
 
     inline fun <R> map(transform: (T) -> R): DoubleCursorPage<R> {
         return DoubleCursorPage(
             contents.map { transform(it) },
+            page,
             cursor,
             size,
         )

--- a/src/main/kotlin/com/wafflytime/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/wafflytime/notification/service/NotificationService.kt
@@ -95,6 +95,12 @@ class NotificationService(
         return CheckNotificationResponse(notificationId)
     }
 
+    fun getNotifications(userId: Long, page: Long, size: Long): CursorPage<NotificationResponse> {
+        return notificationRepository.findAllByReceiverId(userId, page, size).map {
+            NotificationResponse.of(it)
+        }
+    }
+
     fun getNotifications(userId: Long, cursor: Long?, size: Long): CursorPage<NotificationResponse> {
         return notificationRepository.findAllByReceiverId(userId, cursor, size).map {
             NotificationResponse.of(it)

--- a/src/main/kotlin/com/wafflytime/post/api/PostController.kt
+++ b/src/main/kotlin/com/wafflytime/post/api/PostController.kt
@@ -29,10 +29,14 @@ class PostController(
     fun getPosts(
         @UserIdFromToken userId: Long,
         @PathVariable boardId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
     ) : ResponseEntity<CursorPage<PostResponse>> {
-        return ResponseEntity.ok(postService.getPosts(userId, boardId, cursor, size))
+        return ResponseEntity.ok(
+            page?.let { postService.getPosts(userId, boardId, it, size) }
+                ?: postService.getPosts(userId, boardId, cursor, size)
+        )
     }
 
     @PostMapping("/api/board/{boardId}/post")
@@ -85,30 +89,42 @@ class PostController(
     @GetMapping("/api/hotpost")
     fun getHotPost(
         @UserIdFromToken userId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
     ) : ResponseEntity<CursorPage<PostResponse>> {
-        return ResponseEntity.ok(postService.getHotPosts(userId, cursor, size))
+        return ResponseEntity.ok(
+            page?.let { postService.getHotPosts(userId, it, size) }
+                ?: postService.getHotPosts(userId, cursor, size)
+        )
     }
 
     @GetMapping("/api/bestpost")
     fun getBestPost(
         @UserIdFromToken userId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "first") first: Long?,
         @RequestParam(required = false, value = "second") second: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
     ) : ResponseEntity<DoubleCursorPage<PostResponse>> {
-        return ResponseEntity.ok(postService.getBestPosts(userId, first, second, size))
+        return ResponseEntity.ok(
+            page?.let { postService.getBestPosts(userId, it, size) }
+                ?: postService.getBestPosts(userId, first, second, size)
+        )
     }
 
     @GetMapping("/api/posts/search")
     fun searchPosts(
         @UserIdFromToken userId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = true, value = "keyword") keyword: String,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
     ) : ResponseEntity<CursorPage<PostResponse>> {
-        return ResponseEntity.ok(postService.searchPosts(userId, keyword, cursor, size))
+        return ResponseEntity.ok(
+            page?.let { postService.searchPosts(userId, keyword, it, size) }
+                ?: postService.searchPosts(userId, keyword, cursor, size)
+        )
     }
 
     @GetMapping("/api/homeposts")

--- a/src/main/kotlin/com/wafflytime/post/service/PostService.kt
+++ b/src/main/kotlin/com/wafflytime/post/service/PostService.kt
@@ -66,6 +66,14 @@ class PostService(
         return PostResponse.of(userId, post, s3Service.getPreSignedUrlsFromS3Keys(post.images))
     }
 
+    fun getPosts(userId: Long, boardId: Long, page: Long, size: Long): CursorPage<PostResponse> {
+        return postRepository.findAllByBoardId(boardId, page, size).map {
+            PostResponse.of(
+                userId, it, s3Service.getPreSignedUrlsFromS3Keys(it.images)
+            )
+        }
+    }
+
     fun getPosts(userId: Long, boardId: Long, cursor: Long?, size: Long): CursorPage<PostResponse> {
         return postRepository.findAllByBoardId(boardId, cursor, size).map {
             PostResponse.of(
@@ -149,8 +157,20 @@ class PostService(
         return Pair(post, user)
     }
 
+    fun getHotPosts(userId: Long, page: Long, size: Long): CursorPage<PostResponse> {
+        return postRepository.getHotPosts(page, size).map {
+            PostResponse.of(userId, it)
+        }
+    }
+
     fun getHotPosts(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse> {
         return postRepository.getHotPosts(cursor, size).map {
+            PostResponse.of(userId, it)
+        }
+    }
+
+    fun getBestPosts(userId: Long, page: Long, size: Long): DoubleCursorPage<PostResponse> {
+        return postRepository.getBestPosts(page, size).map {
             PostResponse.of(userId, it)
         }
     }
@@ -160,6 +180,12 @@ class PostService(
         val cursor = first?.let { Pair(it, second!!) }
 
         return postRepository.getBestPosts(cursor, size).map {
+            PostResponse.of(userId, it)
+        }
+    }
+
+    fun searchPosts(userId: Long, keyword: String, page: Long, size: Long): CursorPage<PostResponse> {
+        return postRepository.findPostsByKeyword(keyword, page, size).map {
             PostResponse.of(userId, it)
         }
     }

--- a/src/main/kotlin/com/wafflytime/reply/api/ReplyController.kt
+++ b/src/main/kotlin/com/wafflytime/reply/api/ReplyController.kt
@@ -61,11 +61,15 @@ class ReplyController(
         @UserIdFromToken userId: Long,
         @PathVariable boardId: Long,
         @PathVariable postId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "first") first: Long?,
         @RequestParam(required = false, value = "second") second: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long,
     ) : ResponseEntity<DoubleCursorPage<ReplyResponse>>{
-        return ResponseEntity.ok(replyService.getReplies(userId, boardId, postId, first, second, size))
+        return ResponseEntity.ok(
+            page?.let { replyService.getReplies(userId, boardId, postId, first, second, size) }
+                ?: replyService.getReplies(userId, boardId, postId, first, second, size)
+        )
     }
 
     @PostMapping("/api/board/{boardId}/post/{postId}/reply/{replyId}/like")

--- a/src/main/kotlin/com/wafflytime/reply/service/ReplyService.kt
+++ b/src/main/kotlin/com/wafflytime/reply/service/ReplyService.kt
@@ -110,6 +110,14 @@ class ReplyService(
         return replyToResponse(userId, reply)
     }
 
+    fun getReplies(userId: Long, boardId: Long, postId: Long, page: Long, size: Long): DoubleCursorPage<ReplyResponse> {
+        val post = postService.validateBoardAndPost(boardId, postId)
+
+        return replyRepositorySupport.getReplies(post, page, size).map {
+            replyToResponse(userId, it)
+        }
+    }
+
     fun getReplies(userId: Long, boardId: Long, postId: Long, first: Long?, second: Long?, size: Long): DoubleCursorPage<ReplyResponse> {
         val post = postService.validateBoardAndPost(boardId, postId)
         if ((first == null) != (second == null)) throw DoubleCursorMismatch

--- a/src/main/kotlin/com/wafflytime/user/info/api/UserController.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/api/UserController.kt
@@ -68,10 +68,14 @@ class UserController(
     @GetMapping("/api/user/myscrap")
     fun getMyScraps(
         @UserIdFromToken userId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
     ): ResponseEntity<CursorPage<PostResponse>> {
-        return ResponseEntity.ok(userService.getMyScraps(userId, cursor, size))
+        return ResponseEntity.ok(
+            page?.let { userService.getMyScraps(userId, it, size) }
+                ?: userService.getMyScraps(userId, cursor, size)
+        )
     }
 
     @DeleteMapping("/api/user/myscrap")
@@ -85,27 +89,39 @@ class UserController(
     @GetMapping("/api/user/mypost")
     fun getMyPosts(
         @UserIdFromToken userId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
     ) : ResponseEntity<CursorPage<PostResponse>> {
-        return ResponseEntity.ok(userService.getMyPosts(userId, cursor, size))
+        return ResponseEntity.ok(
+            page?.let { userService.getMyPosts(userId, it, size) }
+                ?: userService.getMyPosts(userId, cursor, size)
+        )
     }
 
     @GetMapping("/api/user/myrepliedpost")
     fun getMyRepliedPosts(
         @UserIdFromToken userId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
     ): ResponseEntity<CursorPage<PostResponse>> {
-        return ResponseEntity.ok(userService.getMyRepliedPosts(userId, cursor, size))
+        return ResponseEntity.ok(
+            page?.let { userService.getMyRepliedPosts(userId, it, size) }
+                ?: userService.getMyRepliedPosts(userId, cursor, size)
+        )
     }
 
     @GetMapping("/api/user/notifications")
     fun getNotifications(
         @UserIdFromToken userId: Long,
+        @RequestParam(required = false, value = "page") page: Long?,
         @RequestParam(required = false, value = "cursor") cursor: Long?,
         @RequestParam(required = false, value = "size", defaultValue = "20") size: Long
     ) : ResponseEntity<CursorPage<NotificationResponse>> {
-        return ResponseEntity.ok(notificationService.getNotifications(userId, cursor, size))
+        return ResponseEntity.ok(
+            page?.let { notificationService.getNotifications(userId, it, size) }
+                ?: notificationService.getNotifications(userId, cursor, size)
+        )
     }
 }

--- a/src/main/kotlin/com/wafflytime/user/info/service/UserService.kt
+++ b/src/main/kotlin/com/wafflytime/user/info/service/UserService.kt
@@ -26,11 +26,14 @@ interface UserService {
     fun checkUnivEmailConflict(univEmail: String)
     fun updateUserInfo(userId: Long, request: UpdateUserInfoRequest): UserInfo
     fun updateUserMailVerified(userId: Long, email: String): UserEntity
+    fun getMyScraps(userId: Long, page: Long, size: Long): CursorPage<PostResponse>
     fun getMyScraps(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse>
     fun deleteScrap(userId: Long, postId: Long): DeleteScrapResponse
+    fun getMyPosts(userId: Long, page: Long, size: Long): CursorPage<PostResponse>
     fun getMyPosts(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse>
     fun updateProfileImage(userId: Long, request: UploadProfileImageRequest): UserInfo
     fun deleteProfileImage(userId: Long): UserInfo
+    fun getMyRepliedPosts(userId: Long, page: Long, size: Long): CursorPage<PostResponse>
     fun getMyRepliedPosts(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse>
 }
 
@@ -107,6 +110,12 @@ class UserServiceImpl (
         return user
     }
 
+    override fun getMyScraps(userId: Long, page: Long, size: Long): CursorPage<PostResponse> {
+        return scrapRepository.findScrapsByUserId(userId, page, size).map {
+            PostResponse.of(userId, it.post)
+        }
+    }
+
     override fun getMyScraps(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse> {
         return scrapRepository.findScrapsByUserId(userId, cursor, size).map {
             PostResponse.of(userId, it.post)
@@ -124,8 +133,20 @@ class UserServiceImpl (
         return DeleteScrapResponse(scrap.post.id)
     }
 
+    override fun getMyPosts(userId: Long, page: Long, size: Long): CursorPage<PostResponse> {
+        return postRepository.findAllByWriterId(userId, page, size).map {
+            PostResponse.of(userId, it)
+        }
+    }
+
     override fun getMyPosts(userId: Long, cursor: Long?, size: Long): CursorPage<PostResponse> {
         return postRepository.findAllByWriterId(userId, cursor, size).map {
+            PostResponse.of(userId, it)
+        }
+    }
+
+    override fun getMyRepliedPosts(userId: Long, page: Long, size: Long): CursorPage<PostResponse> {
+        return postRepository.findAllByUserReply(userId, page, size).map {
             PostResponse.of(userId, it)
         }
     }


### PR DESCRIPTION
똑같은 주소의 rest api를 사용하기 위해
`CursorPage`에 `page` field를 추가했습니다.
pageable한 모든 api들은 page를 받으면 offset방식으로 동작하고
page를 받지 못하면 (null이라면) cursor방식으로 동작하는 식입니다.

일단은 빨리하려고 함수들을 복사해서 조금씩 바꾸는 방식으로 했는데,
추후에 리팩토링 하겠습니다. (아직 n+1 문제가 남아있거나 하는 쿼리들도 있어 이부분도 같이 보면서 하면 될 것 같습니다)

또한 마지막 페이지인지 여부도 주면 좋을 것 같아서 그 부분 작업도 추가적으로 해야겠네요