### PR TITLE
fix: updating unread now does not require full chatId list

### DIFF
--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketJsonType.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketJsonType.kt
@@ -1,5 +1,5 @@
 package com.wafflytime.chat.dto
 
 enum class WebSocketJsonType {
-    MESSAGE, NEWCHAT,
+    MESSAGE, NEWCHAT, NEED_UPDATE
 }

--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketUpdateRequired.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketUpdateRequired.kt
@@ -1,5 +1,7 @@
 package com.wafflytime.chat.dto
 
 data class WebSocketUpdateRequired(
+    val chatId: List<Long>,
+    val unread: List<Int>,
     val type: WebSocketJsonType = WebSocketJsonType.NEED_UPDATE
 )

--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketUpdateRequired.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketUpdateRequired.kt
@@ -1,0 +1,5 @@
+package com.wafflytime.chat.dto
+
+data class WebSocketUpdateRequired(
+    val type: WebSocketJsonType = WebSocketJsonType.NEED_UPDATE
+)

--- a/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
+++ b/src/main/kotlin/com/wafflytime/chat/exception/ChatExceptions.kt
@@ -18,6 +18,5 @@ object SelfChatForbidden : Chat400("자신에게 채팅을 보낼 수 없습니�
 object AlreadyBlocked : Chat400("이미 차단한 채팅입니다", 4)
 object AlreadyUnblocked : Chat400("이미 차단 해제한 채팅입니다", 5)
 object ListLengthMismatch : Chat400("채팅 개수가 맞지 않습니다", 6)
-object ListMismatch : Chat400("채팅 목록이 일치하지 않습니다", 7)
 
 object WebsocketAttributeError : Chat500("웹소켓 session attribute 문제", 99)

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -208,18 +208,21 @@ class ChatServiceImpl(
             .sortedWith(compareBy { it.first })
 
         val chatList = chatRepository.findAllByParticipantId(userId)
-        if (len != chatList.size) throw ListLengthMismatch
+        var from = 0
+        val to = chatList.size
 
-        chatList.onEachIndexed { index, chatEntity ->
-            if (chatEntity.id != pairList[index].first) throw ListMismatch
-            chatEntity.run {
+        pairList.forEach { (chatId, unread) ->
+            val result = chatList.subList(from, to).indexOfFirst { it.id == chatId }
+            if (result < 0) throw ChatNotFound
+
+            from += result
+            chatList[from].run {
                 when (userId) {
-                    participant1.id -> unread1 = pairList[index].second
-                    participant2.id -> unread2 = pairList[index].second
+                    participant1.id -> unread1 = unread
+                    participant2.id -> unread2 = unread
                 }
             }
         }
-
     }
 
     private fun getChatEntity(chatId: Long): ChatEntity {

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -224,7 +224,7 @@ class ChatServiceImpl(
             }
         }
 
-        webSocketService.sendUpdateRequiredResponse(userId)
+        webSocketService.sendUpdateRequiredResponse(userId, chatIdList, unreadList)
     }
 
     private fun getChatEntity(chatId: Long): ChatEntity {

--- a/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/ChatService.kt
@@ -223,6 +223,8 @@ class ChatServiceImpl(
                 }
             }
         }
+
+        webSocketService.sendUpdateRequiredResponse(userId)
     }
 
     private fun getChatEntity(chatId: Long): ChatEntity {

--- a/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
+++ b/src/main/kotlin/com/wafflytime/chat/service/WebSocketService.kt
@@ -40,7 +40,7 @@ interface WebSocketService {
     fun removeSession(session: WebSocketSession)
     fun sendMessage(session: WebSocketSession, message: TextMessage)
     fun sendCreateChatResponse(userId: Long, chat: ChatEntity, systemMessage: MessageEntity?, firstMessage: MessageEntity)
-    fun sendUpdateRequiredResponse(userId: Long)
+    fun sendUpdateRequiredResponse(userId: Long, chatId: List<Long>, unread: List<Int>)
 }
 
 @Service
@@ -148,9 +148,9 @@ class WebSocketServiceImpl(
         }
     }
 
-    override fun sendUpdateRequiredResponse(userId: Long) {
+    override fun sendUpdateRequiredResponse(userId: Long, chatId: List<Long>, unread: List<Int>) {
         webSocketSessions[userId]?.run {
-            sendMessage(convertToTextMessage(WebSocketUpdateRequired()))
+            sendMessage(convertToTextMessage(WebSocketUpdateRequired(chatId, unread)))
         }
     }
 


### PR DESCRIPTION
추가)
* 새 웹소켓 세션 연결시 기존 연결 끊어짐
* 웹소켓이 연결되어 있는 상태에서 update unread 요청이 처리된 경우, 웹소켓 세션에도 이 정보 전달
(새 웹소켓이 연결되며 기존 연결이 끊어지는 경우에 해당 상황 발생)