### PR TITLE
fix: wrong target for recevier in ws chat creation info

### DIFF
--- a/src/main/kotlin/com/wafflytime/chat/dto/WebSocketChatCreationInfo.kt
+++ b/src/main/kotlin/com/wafflytime/chat/dto/WebSocketChatCreationInfo.kt
@@ -12,11 +12,12 @@ data class WebSocketChatCreationInfo(
 
         private const val anonymousName = "익명"
 
-        fun of(entity: ChatEntity): WebSocketChatCreationInfo = entity.run {
-            WebSocketChatCreationInfo(
-                id,
-                if (isAnonymous2) anonymousName else participant2.nickname,
+        fun senderAndReceiverPair(entity: ChatEntity): Pair<WebSocketChatCreationInfo, WebSocketChatCreationInfo> = entity.run {
+            Pair(
+                WebSocketChatCreationInfo(id, if(isAnonymous2) anonymousName else participant2.nickname),
+                WebSocketChatCreationInfo(id, if(isAnonymous1) anonymousName else participant1.nickname),
             )
         }
+
     }
 }


### PR DESCRIPTION
웹소켓으로 전달되는 새 채팅방 정보에서 양측에 채팅방 상대가 다르게 나타나도록 수정